### PR TITLE
Add metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "michael@defprotocol.org"
 license          "Apache 2.0"
 description      "Installs/Configures OpsCode Apache Cassandra"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1"
+version          "1.0.0"


### PR DESCRIPTION
[librarian](https://github.com/applicationsonline/librarian) wouldn't pull in the cookbook because the metadata.rb file was missing.
