### PR TITLE
Silence stdout when starting Cassandra

### DIFF
--- a/templates/default/cassandra.init.erb
+++ b/templates/default/cassandra.init.erb
@@ -130,9 +130,7 @@ do_start()
     ulimit -l unlimited
     ulimit -n "$FD_LIMIT"
 
-    cd /
-
-    start_daemon -p $PIDFILE $CASSANDRA_HOME/bin/cassandra -p $PIDFILE
+    start-stop-daemon --start --quiet --oknodo --chdir / --exec /bin/bash --oknodo --pidfile $PIDFILE -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE 2>&1 > /dev/null"
 
     is_running && return 0
     for tries in `seq $WAIT_FOR_START`; do


### PR DESCRIPTION
Here's the other patch for the init script.
