### PR TITLE
Fixing template path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@ include_recipe "cassandra::datastax"
 
 %w(cassandra.yaml cassandra-env.sh).each do |f|
   template File.join(node["cassandra"]["conf_dir"], f) do
-    source "cassandra/#{f}.erb"
+    source "#{f}.erb"
     owner node["cassandra"]["user"]
     group node["cassandra"]["user"]
     mode  0644


### PR DESCRIPTION
Sorry, I got the template path wrong. No prepended `cassandra/` is necessary.
