### PR TITLE
Fixes broken version control and update default version setting to Cassandra v1.2.5.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,13 +1,7 @@
-cassandra_version = "1.2.3"
-
 default[:cassandra] = {
   :cluster_name => "Test Cluster",
   :initial_token => "",
-  :version => cassandra_version,
-  :tarball => {
-    :url => "http://www.eu.apache.org/dist/cassandra/#{cassandra_version}/apache-cassandra-#{cassandra_version}-bin.tar.gz",
-    :md5 => "8e02796b43e4d09a763f15758210519b"
-  },
+  :version => '1.2.5',
   :user => "cassandra",
   :jvm  => {
     :xms => 32,
@@ -34,4 +28,8 @@ default[:cassandra] = {
   :concurrent_reads => 32,
   :concurrent_writes => 32,
   :snitch           => 'SimpleSnitch'
+}
+default[:cassandra][:tarball] = {
+  :url => "http://www.eu.apache.org/dist/cassandra/#{default[:cassandra][:version]}/apache-cassandra-#{default[:cassandra][:version]}-bin.tar.gz",
+  :md5 => "a9b9ea7f168196e647cffaddc643af3a"
 }


### PR DESCRIPTION
When trying to set the version on the cassandra tarball via node[:cassandra][:version] this wasn't recognized due to the local variable cassandra_version in the default attributes of the cassandra cookbook that overrides any such outer setting. However this is fixed now by removing that variable and setting the tarball configuration after version setting.
