### PR TITLE
Dev/fixprecise

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -21,10 +21,10 @@
 # keep this in mind.
 
 apt_repository "datastax" do
-  uri          "http://debian.datastax.com/community"
+  uri          "https://debian.datastax.com/community"
   distribution "stable"
   components   ["main"]
-  key          "http://debian.datastax.com/debian/repo_key"
+  key          "https://debian.datastax.com/debian/repo_key"
 
   action :add
 end


### PR DESCRIPTION
Currently `apt-get install dsc12` fails on Ubuntu 12.04 because `apt-get` only sees `cassandra=2.0.1` by default and doesn't know what to do about a requirement to install `cassandra=1.2.10-1`. I've added a conditional to the recipe to preemptively install the correct version of the cassandra package on Debian machines.

I've laso changed the datastax repo URLs to use HTTPS.
