### PR TITLE
Forgot to include cassandra namespace, causes chef compile error.

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -35,7 +35,7 @@ group node.cassandra.user do
   action :create
 end
 
-[node.cassandra.data_root_dir, node.cassandra.log_dir, node.commitlog_dir].each do |dir|
+[node.cassandra.data_root_dir, node.cassandra.log_dir, node.cassandra.commitlog_dir].each do |dir|
   directory dir do
     owner     node.cassandra.user
     group     node.cassandra.user


### PR DESCRIPTION
Late night change is most always a bad idea..  Merge this fix asap please.
