### PR TITLE
Converted package name into variable, so you could install different versions from the same yum repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,8 @@ default[:cassandra] = {
   :seeds            => [],
   :concurrent_reads => 32,
   :concurrent_writes => 32,
-  :snitch           => 'SimpleSnitch'
+  :snitch           => 'SimpleSnitch',
+  :package_name     => 'dsc12'
 }
 default[:cassandra][:tarball] = {
   :url => "http://www.eu.apache.org/dist/cassandra/#{default[:cassandra][:version]}/apache-cassandra-#{default[:cassandra][:version]}-bin.tar.gz",

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -84,7 +84,7 @@ when "rhel"
 
 end
 
-package "dsc12" do
+package "#{node[:cassandra][:package_name]}" do
   action :install
 end
 


### PR DESCRIPTION
Converted package name into variable, so you could install different versions from the same yum rep. Since we allow template switch based on the attribute, it will be possible to install cassandra 2 using default[:cassandra][:package_name] = "dsc20" in your application cookbook ( and you'll need to do some adjustments to the config file for v2, but it's totally doable in the application cookbook ).
