### PR TITLE
add link to cqlsh

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -109,6 +109,12 @@ template File.join(node.cassandra.bin_dir, "cassandra-cli") do
   mode  0755
 end
 
+template "/usr/local/bin/cqlsh" do
+  source "cqlsh.erb"
+  owner node.cassandra.user
+  group node.cassandra.user
+  mode  0755
+end
 
 # 5. Symlink
 %w(cassandra cassandra-shell cassandra-cli).each do |f|

--- a/templates/default/cqlsh.erb
+++ b/templates/default/cqlsh.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec  <%= node.cassandra.bin_dir %>/cqlsh


### PR DESCRIPTION
I think cqlsh is very important tool. It's python script so simple symlink won't work.
