### PR TITLE
pass all command line arguments to cqlsh

### DIFF
--- a/templates/default/cqlsh.erb
+++ b/templates/default/cqlsh.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec  <%= node.cassandra.bin_dir %>/cqlsh
+exec  <%= node.cassandra.bin_dir %>/cqlsh "$@"


### PR DESCRIPTION
command line arguments to cqlsh aren't passed along by the wrapping shell script, this change fixes that.

behaviour before change:

```
$ cqlsh 192.168.200.11
Connection error: Could not connect to localhost:9160
```

behaviour after change:

```
$ cqlsh 192.168.200.11
Connected to Test Cluster at 192.168.200.11:9160
```
