### PR TITLE
Tarball installation should use version specified in override_attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default[:cassandra] = {
   :snitch_conf      => false
 }
 default[:cassandra][:tarball] = {
-  :url => "http://archive.apache.org/dist/cassandra/#{default[:cassandra][:version]}/apache-cassandra-#{default[:cassandra][:version]}-bin.tar.gz",
+  :url => "http://archive.apache.org/dist/cassandra/#{node[:cassandra][:version]}/apache-cassandra-#{node[:cassandra][:version]}-bin.tar.gz",
   :md5 => "98d266fa0b84b50971e87f0c905bf2df"
 }
 


### PR DESCRIPTION
I tried to install version `2.0.1` of cassandra via tarball recipe and noticed an issues: recipe always downloads default version of cassandra (`apache-cassandra-2.0.3-bin.tar.gz` for example) but saves it into file with name `apache-cassandra-2.0.1-bin.tar.gz`.

PS What do you think about rewriting tarball recipe using `ark` functionality? As I see `ark` cookbook is already in dependencies of  `cassandra-chef-cookbook`...
