### PR TITLE
Provide support for opscenter agents version 4 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ There are also two recipes for DataStax opscenter installation ( `opscenter_agen
  * `node[:cassandra][:opscenter][:agent][:checksum]` (default: "") Required.
  * `node[:cassandra][:opscenter][:agent][:install_dir]` (default: `/opt`)
  * `node[:cassandra][:opscenter][:agent][:install_folder_name]` (default: `opscenter_agent`)
+ * `node[:cassandra][:opscenter][:agent][:binary_name]` (default: `opscenter-agent`) Introduced since Datastax changed agent binary name from opscenter-agent to datastax-agent. **Make sure to set it right if you are updating to 4.0.2**
  * `node[:cassandra][:opscenter][:agent][:server_host]` (default: "" ). If left empty, will use search to get IP by opscenter `server_role` role.
  * `node[:cassandra][:opscenter][:agent][:server_role]` (default: `opscenter_server`). Will be use for opscenter server IP lookup if `:server_host` is not set.
  * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `true`)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,6 +50,7 @@ default[:cassandra][:opscenter][:agent] = {
   :checksum => nil,
   :install_dir => "/opt",
   :install_folder_name => "opscenter_agent",
+  :binary_name => "opscenter-agent",
   :server_host => nil, # if nil, will use search to get IP by server role
   :server_role => "opscenter_server",
   :use_ssl => true

--- a/recipes/opscenter_agent.rb
+++ b/recipes/opscenter_agent.rb
@@ -28,11 +28,15 @@ template "#{agent_dir}/conf/address.yaml" do
   notifies :restart, "service[opscenter-agent]"
 end
 
+
+binary_name = node[:cassandra][:opscenter][:agent][:binary_name]
+binary_grep_str = "[#{binary_name[0]}]#{binary_name[1..-1]}"
+
 service "opscenter-agent" do
   provider Chef::Provider::Service::Simple
   supports :start => true, :status => true, :stop => true
-  start_command "#{agent_dir}/bin/opscenter-agent"
-  status_command "ps aux | grep -q '[o]pscenter-agent'"
-  stop_command "kill $(ps aux | grep '[o]pscenter-agent' | awk '{print $2}')"
+  start_command "#{agent_dir}/bin/#{binary_name}"
+  status_command "ps aux | grep -q '#{binary_grep_str}'"
+  stop_command "kill $(ps aux | grep '#{binary_grep_str}' | awk '{print $2}')"
   action :start
 end


### PR DESCRIPTION
Since datastax changed agent binary name from opscenter-agent to datastax-agent I had to come up with more generic approach and introduced new configurable attribute node[:cassandra][:opscenter][:agent][:binary_name]
