### PR TITLE
Updated the datastax recipe for the yum ~> 3.0 cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ version          "2.0.0"
 
 depends "java"
 depends "apt"
-depends "yum"
+depends "yum", "~> 3.0"
 depends "ark"

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -76,10 +76,10 @@ when "rhel"
   include_recipe "yum"
 
   yum_repository "datastax" do
-    repo_name "datastax"
     description "DataStax Repo for Apache Cassandra"
-    url "http://rpm.datastax.com/community"
-    action :add
+    baseurl "http://rpm.datastax.com/community"
+    gpgcheck false
+    action :create
   end
 
 end


### PR DESCRIPTION
The `yum_repository` LWRP has changed a bit between the `yum` cookbook versions 2.4.4 and 3.0.0. This commit updates the `datastax` repository to work with `yum ~> 3.0`.
