### PR TITLE
fix yum-3.x cookbook issues caused by repo_name returning NoMethodError

### DIFF
--- a/recipes/opscenter_server.rb
+++ b/recipes/opscenter_server.rb
@@ -31,10 +31,10 @@ when "rhel"
   include_recipe "yum"
 
   yum_repository "datastax" do
-    repo_name "datastax"
     description "DataStax Repo for Apache Cassandra"
-    url "http://rpm.datastax.com/community"
-    action :add
+    baseurl "http://rpm.datastax.com/community"
+    gpgcheck false
+    action :create
   end
 end
 package "#{node[:cassandra][:opscenter][:server][:package_name]}" do


### PR DESCRIPTION
This fixes #46 and updates opscenter_server.rb with a datastax repo similar to what is in datastax.rb and should make it work on yum-3.x

Without this it will fail with:

```
192.168.67.4 NoMethodError
192.168.67.4 -------------
192.168.67.4 undefined method `repo_name' for Chef::Resource::YumRepository
192.168.67.4
192.168.67.4
192.168.67.4 Cookbook Trace:
192.168.67.4 ---------------
192.168.67.4   /var/chef/cache/cookbooks/cassandra/recipes/opscenter_server.rb:34:in `block in from_file'
192.168.67.4   /var/chef/cache/cookbooks/cassandra/recipes/opscenter_server.rb:33:in `from_file'
...
...
192.168.67.4  30:  when "rhel"
192.168.67.4  31:    include_recipe "yum"
192.168.67.4  32: 
192.168.67.4  33:    yum_repository "datastax" do
192.168.67.4  34>>     repo_name "datastax"
192.168.67.4  35:      description "DataStax Repo for Apache Cassandra"
192.168.67.4  36:      url "http://rpm.datastax.com/community"
192.168.67.4  37:      action :add
192.168.67.4  38:    end
```
