### PR TITLE
Yum install of dsc20 failing on CentOS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,6 +80,7 @@ default[:cassandra] = {
   :vnodes           => false,
   :seeds            => [node[:ipaddress]],
   :package_name     => 'dsc20',
+  :release          => '1',
   :snitch_conf      => false,
   :enable_assertions => true,
   :jmx_server_hostname => false,

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -101,7 +101,7 @@ when "rhel"
   end
 
   yum_package "#{node.cassandra.package_name}" do
-    version node.cassandra.version
+    version "#{node.cassandra.version}-#{node.cassandra.release}"
     allow_downgrade
   end
 


### PR DESCRIPTION
Getting the below error when attempting to run `cassandra::datastax` on a CentOS 6.4 VM. The recipe was able to add the Datastax yum repo successfully and I can manually install via `yum install dsc20` but for some reason this part of the Chef recipe fails.

```
[2014-04-10T20:48:50+00:00] INFO: Processing yum_package[dsc20] action install (cassandra::datastax line 103)
[2014-04-10T20:48:53+00:00] DEBUG: yum_package[dsc20] checking yum info for dsc20-2.0.6
[2014-04-10T20:48:53+00:00] DEBUG: yum_package[dsc20] installed version: (none) candidate version: 2.0.6-1

================================================================================
Error executing action `install` on resource 'yum_package[dsc20]'
================================================================================


Chef::Exceptions::Package
-------------------------
Version 2.0.6 of dsc20 not found. Did you specify both version and release? (version-release, e.g. 1.84-10.fc6)


Resource Declaration:
---------------------
# In /tmp/vagrant-chef-2/chef-solo-1/cookbooks/cassandra/recipes/datastax.rb

103:   yum_package "#{node.cassandra.package_name}" do
104:     version node.cassandra.version
105:     allow_downgrade
106:   end
107:



Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-2/chef-solo-1/cookbooks/cassandra/recipes/datastax.rb:103:in `from_file'

yum_package("dsc20") do
  provider Chef::Provider::Package::Yum
  action :install
  retries 0
  retry_delay 2
  guard_interpreter :default
  package_name "dsc20"
  version "2.0.6"
  flush_cache {:before=>false, :after=>false}
  cookbook_name :cassandra
  recipe_name "datastax"
end



[2014-04-10T20:48:53+00:00] INFO: Running queued delayed notifications before re-raising exception
[2014-04-10T20:48:53+00:00] DEBUG: Re-raising exception: Chef::Exceptions::Package - yum_package[dsc20] (cassandra::datastax line 103) had an error: Chef::Exceptions::Package: Version 2.0.6 of dsc20 not found. Did you specify both version and release? (version-release, e.g. 1.84-10.fc6)
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package/yum.rb:1136:in `install_package'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package.rb:82:in `block in action_install'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/mixin/why_run.rb:52:in `call'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/mixin/why_run.rb:52:in `add_action'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider.rb:155:in `converge_by'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package.rb:80:in `action_install'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider.rb:120:in `run_action'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource.rb:637:in `run_action'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:49:in `run_action'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `block (2 levels) in converge'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `each'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `block in converge'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection.rb:96:in `execute_each_resource'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:80:in `converge'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:345:in `converge'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:431:in `do_run'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:213:in `block in run'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:207:in `fork'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:207:in `run'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application.rb:217:in `run_chef_client'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:221:in `block in run_application'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:213:in `loop'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:213:in `run_application'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application.rb:67:in `run'
  /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/bin/chef-solo:25:in `<top (required)>'
  /usr/bin/chef-solo:23:in `load'
  /usr/bin/chef-solo:23:in `<main>'
[2014-04-10T20:48:53+00:00] ERROR: Running exception handlers
[2014-04-10T20:48:53+00:00] ERROR: Exception handlers complete
[2014-04-10T20:48:53+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-04-10T20:48:53+00:00] DEBUG: Chef::Exceptions::Package: yum_package[dsc20] (cassandra::datastax line 103) had an error: Chef::Exceptions::Package: Version 2.0.6 of dsc20 not found. Did you specify both version and release? (version-release, e.g. 1.84-10.fc6)
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package/yum.rb:1136:in `install_package'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package.rb:82:in `block in action_install'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/mixin/why_run.rb:52:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/mixin/why_run.rb:52:in `add_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider.rb:155:in `converge_by'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider/package.rb:80:in `action_install'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/provider.rb:120:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource.rb:637:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:49:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:81:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/resource_collection.rb:96:in `execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/runner.rb:80:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:345:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:431:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:213:in `block in run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:207:in `fork'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/client.rb:207:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application.rb:217:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:221:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:213:in `loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application/solo.rb:213:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/lib/chef/application.rb:67:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.2/bin/chef-solo:25:in `<top (required)>'
/usr/bin/chef-solo:23:in `load'
/usr/bin/chef-solo:23:in `<main>'
[2014-04-10T20:48:53+00:00] ERROR: yum_package[dsc20] (cassandra::datastax line 103) had an error: Chef::Exceptions::Package: Version 2.0.6 of dsc20 not found. Did you specify both version and release? (version-release, e.g. 1.84-10.fc6)
[2014-04-10T20:48:53+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
