### PR TITLE
Make stream_throughput_outbound_megabits_per_sec configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -86,6 +86,7 @@ default[:cassandra] = {
   :enable_assertions => true,
   :jmx_server_hostname => false,
   :auto_bootstrap => true,
+  :stream_throughput_outbound_megabits_per_sec => 400
 }
 
 default[:cassandra][:jna] = {

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -489,7 +489,7 @@ compaction_preheat_key_cache: <%= cassandra_bool_config(node[:cassandra][:compac
 # mostly sequential IO when streaming data during bootstrap or repair, which
 # can lead to saturating the network connection and degrading rpc performance.
 # When unset, the default is 400 Mbps or 50 MB/s.
-# stream_throughput_outbound_megabits_per_sec: 400
+stream_throughput_outbound_megabits_per_sec: <%= node[:cassandra][:stream_throughput_outbound_megabits_per_sec] %>
 
 # How long the coordinator should wait for read operations to complete
 read_request_timeout_in_ms: <%= node[:cassandra][:read_request_timeout_in_ms] %>


### PR DESCRIPTION
Makes the stream_throughput_outbound_megabits_per_sec attribute configurable, with the default set to the current value.
