### PR TITLE
Pin cassandra version (apt)

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -87,6 +87,10 @@ when "debian"
         action :install
         version node.cassandra.version
       end
+      apt_preference "cassandra" do
+        pin "version #{node.cassandra.version}"
+        pin_priority "700"
+      end
     end
   end
 


### PR DESCRIPTION
If you need to use version 1.2.x, without pinning, `apt-get upgrade` (or `dist-upgrade`) will upgrade to cassandra 2.x
