### PR TITLE
Add slash to file between path components

### DIFF
--- a/templates/default/debian.cassandra.init.erb
+++ b/templates/default/debian.cassandra.init.erb
@@ -73,7 +73,7 @@ do_start()
         --chuid $USER:$GROUP \
         --exec /bin/bash \
         --pidfile $PIDFILE \
-        -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE > <%= node.cassandra.log_dir %>boot.log 2>&1"
+        -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE > <%= node.cassandra.log_dir %>/boot.log 2>&1"
 
     is_running && return 0
 


### PR DESCRIPTION
If a slash is not present in the log_dir attribute then the concatenation in the debian init script produces
a path where the `cassandra` user has no privileges to write: `/var/log/cassandraboot.log`

When the init file runs it touches the pid file, then cassandra fails to
start, then all subsequent times the init file is invoked, the pid file
exists and no pid is inside so `is_running` fails always.

I prefer to put the slash in this template so the attribute can be
specified in any way. Two slashes work, none not.
