### PR TITLE
Note regarding datastax is the default if you include_recipe 'cassandra'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ and thus can be used to provision any specific version.
 
 The latter uses DataStax repository via packages. You can install different versions (ex. dsc20 for v2.0) available in the repository by altering `:package_name` attribute (`dsc20` by default).
 
+include_recipe `cassandra` uses  `cassandra::datastax` as the default.
+
 ### DataStax Enterprise
 
 You can also install the DataStax Enterprise edition by adding `node[:cassandra][:dse]` attributes according to the datastax.rb.


### PR DESCRIPTION
I was lazy and left in include_recipe 'cassandra' when I saw default.rb used cassandra::datastax as the default.  Might want to make a note of that fact for others.
