### PR TITLE
Changed default release number; 2.0.9-2 is not present in Debian nor in ...

### DIFF
--- a/attributes/datastax.rb
+++ b/attributes/datastax.rb
@@ -2,5 +2,5 @@
 include_attribute "cassandra::common"
 
 default[:cassandra][:package_name]  = 'dsc20'
-default[:cassandra][:release]       = '2'
+default[:cassandra][:release]       = '1'
 


### PR DESCRIPTION
Changed default release number; 2.0.9-2 is not present in Debian nor RHEL repo.

As of the 26th of August, 2.0.9-2 is not yet available in the official Datastax repositories at:
- http://rpm.datastax.com/community/noarch/
- http://debian.datastax.com/community/pool/

Release 2 might soon follow, but the current state of the master branch is not deployable in its current state without customizing the parameter.
