### PR TITLE
preparing for v2.1

### DIFF
--- a/attributes/common.rb
+++ b/attributes/common.rb
@@ -33,6 +33,19 @@ default[:cassandra] = {
   :log_dir    => "/var/log/cassandra",
   :rootlogger => "INFO,stdout,R",
 
+  :logback    => {
+    :file     => {
+      :max_file_size    => '20MB',
+      :max_index        => 20,
+      :min_index        => 1,
+      :pattern          => '%-5level [%thread] %date{ISO8601} %F:%L - %msg%n'
+    },
+    :stdout   => {
+      :enable   => true,
+      :pattern  => '%-5level %date{HH:mm:ss,SSS} %msg%n'
+    }
+  },
+
   :auto_bootstrap => true,
   :hinted_handoff_enabled               => true,
   :max_hint_window_in_ms                => 10800000, # 3 hours
@@ -113,7 +126,26 @@ default[:cassandra] = {
   :snitch_conf      => false,
   :enable_assertions => true,
   :internode_compression => 'all', # all, dc, none
-  :jmx_server_hostname => false
+  :jmx_server_hostname => false,
+
+  # C* 2.1.0
+  :broadcast_rpc_address          => node[:ipaddress],
+  :tombstone_failure_threshold    => 100000,
+  :tombstone_warn_threshold       => 1000,
+  :sstable_preemptive_open_interval_in_mb   => 50,
+  :memtable_allocation_type       => 'heap_buffers',
+  :index_summary_capacity_in_mb   => '',
+  :index_summary_resize_interval_in_minutes => 60,
+  :concurrent_counter_writes      => 32,
+  :counter_cache_save_period      => 7200,
+  :counter_cache_size_in_mb       => '',
+  :counter_write_request_timeout_in_ms      => 5000,
+  :commit_failure_policy          => 'stop',
+  :cas_contention_timeout_in_ms   => 1000,
+  :batch_size_warn_threshold_in_kb          => 5,
+  :batchlog_replay_throttle_in_kb => 1024
+
+
 }
 
 default[:cassandra][:encryption][:server] = {

--- a/attributes/version.rb
+++ b/attributes/version.rb
@@ -1,0 +1,15 @@
+
+case node[:cassandra][:version]
+# Report if jamm version is not correct for 0.x or 1.x version
+when /^0\./,/^1\./,/^2\.0/
+  # < 2.1 Versions
+  default[:cassandra][:log_config_files] = %w(log4j-server.properties)
+  default[:cassandra][:jamm_version] = '0.2.5'
+  default[:cassandra][:cassandra_old_version_20] = true
+else
+  # >= 2.1 Version
+  default[:cassandra][:log_config_files] = %w(logback.xml logback-tools.xml)
+  default[:cassandra][:setup_jna] = false
+  default[:cassandra][:jamm_version] = '0.2.6'
+  default[:cassandra][:cassandra_old_version_20] = false
+end

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -169,7 +169,19 @@ end
   end
 end
 
-%w(cassandra.yaml cassandra-env.sh log4j-server.properties).each do |f|
+%w(cassandra.yaml cassandra-env.sh).each do |f|
+  template File.join(node.cassandra.conf_dir, f) do
+    cookbook node.cassandra.templates_cookbook
+    source "#{f}.erb"
+    owner node.cassandra.user
+    group node.cassandra.group
+    mode  "0644"
+    notifies :restart, "service[cassandra]", :delayed if node.cassandra.notify_restart
+  end
+end
+
+
+node.cassandra.log_config_files.each do |f|
   template File.join(node.cassandra.conf_dir, f) do
     cookbook node.cassandra.templates_cookbook
     source "#{f}.erb"

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -183,7 +183,7 @@ JVM_OPTS="$JVM_OPTS -ea"
 if [ "$JVM_VENDOR" != "OpenJDK" -o "$JVM_VERSION" \> "1.6.0" ] \
       || [ "$JVM_VERSION" = "1.6.0" -a "$JVM_PATCH_VERSION" -ge 23 ]
 then
-    JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-0.2.5.jar"
+  JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/jamm-<%= node[:cassandra][:jamm_version] -%>.jar"
 fi
 
 # some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -304,8 +304,11 @@ concurrent_writes: <%= node[:cassandra][:concurrent_writes] %>
 # the number of full memtables to allow pending flush, that is,
 # waiting for a writer thread.  At a minimum, this should be set to
 # the maximum number of secondary indexes created on a single CF.
+<% if node[:cassandra][:cassandra_old_version_20] -%>
 memtable_flush_queue_size: <%= node[:cassandra][:memtable_flush_queue_size] %>
-
+<% else -%>
+#memtable_flush_queue_size: <%= node[:cassandra][:memtable_flush_queue_size] %>
+<% end -%>
 # Whether to, when doing sequential writing, fsync() at intervals in
 # order to force the operating system to flush the dirty
 # buffers. Enable this to avoid sudden dirty buffer flushing from
@@ -453,7 +456,11 @@ column_index_size_in_kb: <%= node[:cassandra][:column_index_size_in_kb] %>
 # Size limit for rows being compacted in memory.  Larger rows will spill
 # over to disk and use a slower two-pass compaction process.  A message
 # will be logged specifying the row key.
+<% if node[:cassandra][:cassandra_old_version_20] -%>
 in_memory_compaction_limit_in_mb: <%= node[:cassandra][:in_memory_compaction_limit_in_mb] %>
+<% else -%>
+#in_memory_compaction_limit_in_mb: <%= node[:cassandra][:in_memory_compaction_limit_in_mb] %>
+<% end -%>
 
 # Number of simultaneous compactions to allow, NOT including
 # validation "compactions" for anti-entropy repair.  Simultaneous
@@ -473,7 +480,11 @@ in_memory_compaction_limit_in_mb: <%= node[:cassandra][:in_memory_compaction_lim
 # This is usually only useful for SSD-based hardware: otherwise,
 # your concern is usually to get compaction to do LESS i/o (see:
 # compaction_throughput_mb_per_sec), not more.
+<% if node[:cassandra][:cassandra_old_version_20] -%>
 multithreaded_compaction: <%= cassandra_bool_config(node[:cassandra][:multithreaded_compaction]) %>
+<% else -%>
+#multithreaded_compaction: <%= cassandra_bool_config(node[:cassandra][:multithreaded_compaction]) %>
+<% end -%>
 
 # Throttles compaction to the given total throughput across the entire
 # system. The faster you insert data, the faster you need to compact in
@@ -486,7 +497,11 @@ compaction_throughput_mb_per_sec: <%= node[:cassandra][:compaction_throughput_mb
 # Track cached row keys during compaction, and re-cache their new
 # positions in the compacted sstable.  Disable if you use really large
 # key caches.
+<% if node[:cassandra][:cassandra_old_version_20] -%>
 compaction_preheat_key_cache: <%= cassandra_bool_config(node[:cassandra][:compaction_preheat_key_cache]) %>
+<% else -%>
+#compaction_preheat_key_cache: <%= cassandra_bool_config(node[:cassandra][:compaction_preheat_key_cache]) %>
+<% end -%>
 
 # Throttles all outbound streaming file transfers on this node to the
 # given total throughput in Mbps. This is necessary because Cassandra does
@@ -723,3 +738,110 @@ inter_dc_tcp_nodelay: true
 <% if node[:cassandra][:auto_bootstrap] == false %>
 auto_bootstrap: false
 <% end %>
+
+<% if not node[:cassandra][:cassandra_old_version_20] -%>
+# C* >= 2.1.0 params
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+broadcast_rpc_address: <%= node[:cassandra][:broadcast_rpc_address] %>
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: <%= node[:cassandra][:tombstone_warn_threshold] %>
+tombstone_failure_threshold: <%= node[:cassandra][:tombstone_failure_threshold] %>
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: <%= node[:cassandra][:sstable_preemptive_open_interval_in_mb] %>
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#   heap_buffers:    on heap nio buffers
+#   offheap_buffers: off heap (direct) nio buffers
+#   offheap_objects: native memory, eliminating nio buffer heap overhead
+memtable_allocation_type: <%= node[:cassandra][:memtable_allocation_type] %>
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb: <%= node[:cassandra][:index_summary_capacity_in_mb] %>
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: <%= node[:cassandra][:index_summary_resize_interval_in_minutes] %>
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_counter_writes: <%= node[:cassandra][:concurrent_counter_writes] %>
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: <%= node[:cassandra][:counter_cache_save_period] %>
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb: <%= node[:cassandra][:counter_cache_size_in_mb] %>
+
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: <%= node[:cassandra][:counter_write_request_timeout_in_ms] %>
+
+# policy for commit disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: <%= node[:cassandra][:commit_failure_policy] %>
+
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: <%= node[:cassandra][:cas_contention_timeout_in_ms] %>
+
+# Log WARN on any batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: <%= node[:cassandra][:batch_size_warn_threshold_in_kb] %>
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: <%= node[:cassandra][:batchlog_replay_throttle_in_kb] %>
+<% end -%>

--- a/templates/default/logback-tools.xml.erb
+++ b/templates/default/logback-tools.xml.erb
@@ -1,0 +1,38 @@
+<!--
+#
+# This file is managed by Chef.
+# Do NOT modify this file directly.
+#
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<configuration>
+  <appender name="STDERR" target="System.err" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>WARN</level>
+    </filter>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -1,0 +1,62 @@
+<!--
+#
+# This file is managed by Chef.
+# Do NOT modify this file directly.
+#
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<configuration scan="true">
+  <jmxConfigurator />
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file><%= node.cassandra.log_dir %>/system.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern><%= node.cassandra.log_dir %>/system.log.%i.zip</fileNamePattern>
+      <minIndex><%= node.cassandra.logback.file.min_index %></minIndex>
+      <maxIndex><%= node.cassandra.logback.file.max_index %></maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize><%= node.cassandra.logback.file.max_file_size %></maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern><%= node.cassandra.logback.file.pattern %></pattern>
+      <!-- old-style log format
+      <pattern>%5level [%thread] %date{ISO8601} %F (line %L) %msg%n</pattern>
+      -->
+    </encoder>
+  </appender>
+
+  <% if node.cassandra.logback.stdout.enable -%>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern><%= node.cassandra.logback.stdout.pattern %></pattern>
+    </encoder>
+  </appender>
+  <% end -%>
+
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <% if node.cassandra.logback.stdout.enable -%>
+    <appender-ref ref="STDOUT" />
+    <% end -%>
+  </root>
+
+  <logger name="com.thinkaurelius.thrift" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
- Added `attributes/version.rb` for v2.1 cookbook attributes change
- Added logback attributes and config files for v2.1
- Disabled `log4j-server.properties` for v2.1
- Added v2.1 new parameters to `cassandra.yaml` 
- Disabled old incompatible v2.1 `cassandra.yaml` parameters
- Added `node[:cassandra][:jamm_version]` attribute for `cassandra-env.sh` jamm lib
- Disabled `node[:cassandra][:setup_jna]` for v2.1, jna lib is part of C\* package now

Tested v2.1 tarball setup and upgrade from v2.0.8. Hopefully commit will work for dsc21/dsc20. 

Provide commits for Issue #107  #109 
