### PR TITLE
use the use ssl agent attribute in opscenterd config

### DIFF
--- a/templates/default/opscenterd.conf.erb
+++ b/templates/default/opscenterd.conf.erb
@@ -12,6 +12,11 @@ port = 7199
 port = <%= node[:cassandra][:opscenter][:server][:port] %>
 interface = <%= node[:cassandra][:opscenter][:server][:interface] %>
 
+<% unless node[:cassandra][:opscenter][:agent][:use_ssl] %>
+[agents]
+use_ssl = false
+<% end %>
+
 [logging]
 # level may be TRACE, DEBUG, INFO, WARN, or ERROR
 #level = INFO


### PR DESCRIPTION
opscenterd defaults to use ssl, the agent can be overridden to not use ssl, in which case you need to be able to config the agent in the opscenterd config.
