### PR TITLE
Fixing symlink to config dir for C* 2.1

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -141,13 +141,19 @@ when "rhel"
     options node.cassandra.yum.options
   end
 
-  # Ignoring /etc/cassandra/conf completely and using /usr/share/cassandra/conf
+  # Creating symlink from user defined config directory to default
+  directory File.dirname(node.cassandra.conf_dir) do
+    owner     node.cassandra.user
+    group     node.cassandra.group
+    recursive true
+    mode      0755
+    action    :create
+  end
   link node.cassandra.conf_dir do
     to        node.default[:cassandra][:conf_dir]
     owner     node.cassandra.user
     group     node.cassandra.group
     action    :create
-    not_if    do File.exists?(node.cassandra.conf_dir) end
   end
 end
 


### PR DESCRIPTION
For cassandra 2.1 the hard coded link to /usr/share/cassandra/default.conf/ won't work since it is never created and /etc/cassandra/default.conf/ is used instead. Fixed it by linking to default conf (/etc/cassandra/conf) which works for both versions.
In the medium term, it might be a better solution to modify cassandra.in.sh to set CASSANDRA_CONF making the hard coded symlink redundant...
