### PR TITLE
Fixed cluster_name change when installed with ubuntu package

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -98,7 +98,7 @@ when "debian"
   end
 
   execute "set_cluster_name" do
-    command   "/usr/bin/cqlsh -e \"update system.local set cluster_name='#{node.cassandra.cluster_name}' where key='local';\""
+    command   "/usr/bin/cqlsh -e \"update system.local set cluster_name='#{node.cassandra.cluster_name}' where key='local';\"; /usr/bin/nodetool flush;"
     notifies  :restart, "service[cassandra]", :delayed
     action    :nothing
   end


### PR DESCRIPTION
There has been a discussion https://github.com/michaelklishin/cassandra-chef-cookbook/issues/92 related to some problems with custom cluster_name. Unfortunately solution provided in PR https://github.com/michaelklishin/cassandra-chef-cookbook/pull/105 doesn't help. What is missed is a 'nodetool flush' that sends that update to sstables.  
To make things simpler I have added missed command at the end of cqlsh call.

Tested on Ubuntu 14.04.1 LTS, and dsc 2.0.10
