### PR TITLE
Made all Java includes conditional

### DIFF
--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe "java"
+if node[:cassandra][:install_java] then
+  include_recipe "java"
+end
 
 case node["platform_family"]
 when "debian"
@@ -65,7 +67,7 @@ if !server_ip
   else
     return # Continue until opscenter will come up
   end
-end 
+end
 
 package "#{node[:cassandra][:opscenter][:agent][:package_name]}" do
   action :install

--- a/recipes/opscenter_server.rb
+++ b/recipes/opscenter_server.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe "java"
+if node[:cassandra][:install_java] then
+  include_recipe "java"
+end
 
 case node["platform_family"]
 when "debian"

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -35,7 +35,9 @@ node.default[:cassandra][:data_dir] = File.join(node.cassandra.root_dir, 'data')
 node.default[:cassandra][:commitlog_dir] = File.join(node.cassandra.root_dir, 'commitlog')
 node.default[:cassandra][:saved_caches_dir] = File.join(node.cassandra.root_dir, 'saved_caches')
 
-include_recipe "java"
+if node[:cassandra][:install_java] then
+  include_recipe "java"
+end
 
 # 1. Validate node.cassandra.cluster_name
 Chef::Application.fatal!("attribute node['cassandra']['cluster_name'] not defined") unless node.cassandra.cluster_name


### PR DESCRIPTION
Ran into the following issue:
- The dsc20 rpm in the Datastax repo has a faulty dependency on jdk6. dsc20 and dsc21 need jdk7 to run.
- This jdk6 rpm installs itself with an update-alternatives priority of 16000, overruling most default setups. Installing dsc20 and dsc21 manually on a clean CentOS installation without this cookbook also resulted in a broken Cassandra installation. (Unsupported major.minor version 51.0) I'll try to report this to the repo maintainer after.
- We run our own minimal Java cookbook (say 'timo-java') at the start of the Chef run using the same node attrs and update-alternatives JVM target path as the official 'java' cookbook. 'timo-java' sets the update-alternatives prio to 20000 to make sure our Java is master.
- Because this Cassandra cookbook is only included much later in the run and 'java' is always included, this overwrites the update-alternatives prio of 'timo-java' with its chosen value, 1062, resulting in a default of jdk6.

Regardless of the fact that we're using a custom Java cookbook in our environment, I believe having a non-togglable 'java' include in the recipes below is an error. This trumps the user's expectations after setting node.cassandra.install_java to false (it did for me), so I hope this patch is an overall improvement to the user friendliness of the cookbook. (I love it so far!)

Cheers

Timo
