### PR TITLE
Creating /etc/cassandra/conf directory before yaml file gets copied into it. In case it is not created, script execution will fail.

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -252,6 +252,11 @@ if node.cassandra.setup_jamm
   end
 end
 
+file "/etc/default/#{node.cassandra.service_name}" do
+    content "JAVA_HOME=#{node['java']['java_home']}"
+    mode 00755
+end
+
 service "cassandra" do
   supports :restart => true, :status => true
   service_name node.cassandra.service_name


### PR DESCRIPTION
Below script fails in case if _conf_dir_ is not created before it gets executed.

``` ruby
%w(cassandra.yaml cassandra-env.sh).each do |f|
  template File.join(node.cassandra.conf_dir, f) do
     cookbook node.cassandra.templates_cookbook
     source "#{f}.erb"
     owner node.cassandra.user
     group node.cassandra.group
     mode  "0644"
     notifies :restart, "service[cassandra]", :delayed if node.cassandra.notify_restart
   end
 end
```
