### PR TITLE
reverting PR #127 and apt preference fix

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -250,11 +250,6 @@ if node.cassandra.setup_jamm
   end
 end
 
-file "/etc/default/#{node.cassandra.service_name}" do
-    content "JAVA_HOME=#{node['java']['java_home']}"
-    mode 00755
-end
-
 service "cassandra" do
   supports :restart => true, :status => true
   service_name node.cassandra.service_name


### PR DESCRIPTION
- reverted PR #127
- updated apt dsc/dse install, i guess

@michaelklishin Is it me or attribute `node['cassandra']['package_name']` is not suppose to be used for `apt-get install` like used for `rhel` platform family.

`node['cassandra']['version']` is used to pin the preference for `cassandra` package.

Also i guess apt `preference` is also required for dse, in which case need to declare it for the platform family not just for `dsc`.
