### PR TITLE
Use opscenter package instead of opscenter-free.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -223,7 +223,7 @@ default[:cassandra][:tarball] = {
 }
 
 default[:cassandra][:opscenter][:server] = {
-  :package_name => "opscenter-free",
+  :package_name => "opscenter",
   :port => "8888",
   :interface => "0.0.0.0"
 }


### PR DESCRIPTION
These packages were merged together after OpsCenter 4.0 was released:
http://www.datastax.com/documentation/opscenter/5.0/opsc/release_notes/opscReleaseNotes40_r.html
