### PR TITLE
Fix datastax agent configuration

### DIFF
--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -79,8 +79,10 @@ service "datastax-agent" do
 end
 
 
-template "/etc/datastax-agent/address.yaml" do
+template "/var/lib/datastax-agent/conf/address.yaml" do
   mode 0644
+  owner 'opscenter-agent'
+  group 'opscenter-agent'
   source "opscenter-agent.conf.erb"
   variables({
     :server_ip => server_ip


### PR DESCRIPTION
Move agent config to /var/lib/datastax-agent/conf/address.yaml.
Make config file ownership identical to package version.
