### PR TITLE
fixed snitch configuration not generating topology correctly

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,7 +118,6 @@ default['cassandra']['heap_new_size'] = nil
 default['cassandra']['xss'] = '256k'
 default['cassandra']['vnodes'] = false
 default['cassandra']['seeds'] = node['ipaddress']
-default['cassandra']['snitch_conf'] = false
 default['cassandra']['enable_assertions'] = true
 default['cassandra']['internode_compression'] = 'all' # all, dc, none
 default['cassandra']['jmx_server_hostname'] = false

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -147,7 +147,7 @@ template ::File.join(node['cassandra']['conf_dir'], 'cassandra-topology.properti
   mode 0644
   variables(:snitch => node['cassandra']['snitch_conf'])
   notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
-  only_if { node['cassandra']['snitch_conf'] }
+  only_if { node['cassandra'].attribute?('snitch_conf') }
 end
 
 template ::File.join(node['cassandra']['conf_dir'], 'cassandra-rackdc.properties') do

--- a/templates/default/cassandra-topology.properties.erb
+++ b/templates/default/cassandra-topology.properties.erb
@@ -4,4 +4,4 @@
 #
 # Cassandra Node IP=Data Center:Rack
 
-default=<%= @snitch['default']['dc'] %>:<%= @snitch['default']['rac'] %>
+default=<%= @snitch['dc'] %>:<%= @snitch['rac'] %>


### PR DESCRIPTION
errors were generated when this recipe was used in chef 10.18.2
