### PR TITLE
Add attribute to create Cassandra as a system user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,7 @@ default['cassandra']['user'] = 'cassandra'
 default['cassandra']['group'] = 'cassandra'
 default['cassandra']['setup_user'] = true
 default['cassandra']['user_home'] = nil
+default['cassandra']['system_user'] = true
 default['cassandra']['version'] = '2.0.9'
 default['cassandra']['pid_dir'] = '/var/run/cassandra'
 default['cassandra']['dir_mode'] = '0755'

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -18,6 +18,7 @@
 #
 
 group node['cassandra']['group'] do
+  system node['cassandra']['system_user']
   action :create
 end
 
@@ -25,6 +26,7 @@ user node['cassandra']['user'] do
   comment 'Cassandra Server user'
   gid node['cassandra']['group']
   home node['cassandra']['user_home'] if node['cassandra']['user_home']
+  system node['cassandra']['system_user']
   shell '/bin/bash'
   action :create
 end


### PR DESCRIPTION
When installing cassandra via the datastax or apache packages, the Cassandra user is always installed as a system user.
This means that the uid will be created between SYS_UID_MIN and SYS_UID_MAX as defined in `/etc/login.defs`, which
helps prevent conflicts with other users created later.

This commit adds an attribute so that when `setup_user` is set to true, the `cassandra::user` recipe will create a system user.
Existing systems will be unaffected, as the `user` resource does not modify the already-created user.
