### PR TITLE
Factorize and unify repository configuration

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -49,7 +49,7 @@ when 'debian'
     package 'apt-transport-https'
 
     apt_repository node['cassandra']['apt']['repo'] do
-      uri "http://#{dse_credentials['username']}:#{dse_credentials['password']}@debian.datastax.com/enterprise"
+      uri "https://#{dse_credentials['username']}:#{dse_credentials['password']}@debian.datastax.com/enterprise"
       distribution node['cassandra']['apt']['distribution']
       components node['cassandra']['apt']['components']
       key node['cassandra']['apt']['repo_key']
@@ -112,7 +112,7 @@ when 'rhel'
 
     yum_repository node['cassandra']['yum']['repo'] do
       description node['cassandra']['yum']['description']
-      baseurl "http://#{dse_credentials['username']}:#{dse_credentials['password']}@rpm.datastax.com/enterprise"
+      baseurl "https://#{dse_credentials['username']}:#{dse_credentials['password']}@rpm.datastax.com/enterprise"
       mirrorlist node['cassandra']['yum']['mirrorlist']
       gpgcheck node['cassandra']['yum']['gpgcheck']
       enabled node['cassandra']['yum']['enabled']

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -18,44 +18,7 @@
 #
 
 include_recipe 'java' if node['cassandra']['install_java']
-
-case node['platform_family']
-when 'debian'
-
-  if node['cassandra']['dse']
-    dse = node['cassandra']['dse']
-    if dse['credentials']['databag']
-      dse_credentials = Chef::EncryptedDataBagItem.load(dse['credentials']['databag']['name'], dse['credentials']['databag']['item'])[dse['credentials']['databag']['entry']]
-    else
-      dse_credentials = dse['credentials']
-    end
-    apt_repository 'datastax' do
-      uri "http://#{dse_credentials['username']}:#{dse_credentials['password']}@debian.datastax.com/enterprise"
-      distribution 'stable'
-      components ['main']
-      key 'https://debian.datastax.com/debian/repo_key'
-      action :add
-    end
-  else
-    apt_repository 'datastax' do
-      uri 'https://debian.datastax.com/community'
-      distribution 'stable'
-      components ['main']
-      key 'https://debian.datastax.com/debian/repo_key'
-      action :add
-    end
-  end
-
-when 'rhel'
-  include_recipe 'yum'
-
-  yum_repository 'datastax' do
-    description 'DataStax Repo for Apache Cassandra'
-    baseurl 'http://rpm.datastax.com/community'
-    gpgcheck false
-    action :create
-  end
-end
+include_recipe 'cassandra::repositories'
 
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 unless server_ip && Chef::Config[:solo]

--- a/recipes/opscenter_server.rb
+++ b/recipes/opscenter_server.rb
@@ -18,44 +18,8 @@
 #
 
 include_recipe 'java' if node['cassandra']['install_java']
+include_recipe 'cassandra::repositories'
 
-case node['platform_family']
-when 'debian'
-
-  if node['cassandra']['dse']
-    dse = node['cassandra']['dse']
-    if dse['credentials']['databag']
-      dse_credentials = Chef::EncryptedDataBagItem.load(dse['credentials']['databag']['name'], dse['credentials']['databag']['item'])[dse['credentials']['databag']['entry']]
-    else
-      dse_credentials = dse['credentials']
-    end
-    apt_repository 'datastax' do
-      uri "http://#{dse_credentials['username']}:#{dse_credentials['password']}@debian.datastax.com/enterprise"
-      distribution 'stable'
-      components ['main']
-      key 'https://debian.datastax.com/debian/repo_key'
-      action :add
-    end
-  else
-    apt_repository 'datastax' do
-      uri 'https://debian.datastax.com/community'
-      distribution 'stable'
-      components ['main']
-      key 'https://debian.datastax.com/debian/repo_key'
-      action :add
-    end
-  end
-
-when 'rhel'
-  include_recipe 'yum'
-
-  yum_repository 'datastax' do
-    description 'DataStax Repo for Apache Cassandra'
-    baseurl 'http://rpm.datastax.com/community'
-    gpgcheck false
-    action :create
-  end
-end
 package node['cassandra']['opscenter']['server']['package_name']
 
 service 'opscenterd' do

--- a/recipes/repositories.rb
+++ b/recipes/repositories.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook Name:: cassandra
+# Recipe:: datastax
+#
+# Copyright 2011-2012, Michael S Klishin & Travis CI Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node['cassandra']['dse']
+  dse = node['cassandra']['dse']
+  if dse['credentials']['databag']
+    dse_credentials = Chef::EncryptedDataBagItem.load(dse['credentials']['databag']['name'], dse['credentials']['databag']['item'])[dse['credentials']['databag']['entry']]
+  else
+    dse_credentials = dse['credentials']
+  end
+end
+
+case node['platform_family']
+when 'debian'
+  if node['cassandra']['dse']
+    package 'apt-transport-https'
+  end
+  
+  apt_repository node['cassandra']['apt']['repo'] do
+    if node['cassandra']['dse']
+      uri "https://#{dse_credentials['username']}:#{dse_credentials['password']}@debian.datastax.com/enterprise"
+    else
+      uri node['cassandra']['apt']['uri']
+    end
+    distribution node['cassandra']['apt']['distribution']
+    components node['cassandra']['apt']['components']
+    key node['cassandra']['apt']['repo_key']
+    action node['cassandra']['apt']['action']
+  end
+when 'rhel'
+  include_recipe 'yum'
+  
+  yum_repository node['cassandra']['yum']['repo'] do
+    if node['cassandra']['dse']
+      baseurl "https://#{dse_credentials['username']}:#{dse_credentials['password']}@rpm.datastax.com/enterprise"
+    else
+      baseurl node['cassandra']['yum']['baseurl']
+    end
+    description node['cassandra']['yum']['description']
+    mirrorlist node['cassandra']['yum']['mirrorlist']
+    gpgcheck node['cassandra']['yum']['gpgcheck']
+    enabled node['cassandra']['yum']['enabled']
+    action node['cassandra']['yum']['action']
+  end
+end


### PR DESCRIPTION
I have factorized repository configurations into a single recipe because installing the opscenter agent (or server) would cause my custom mirror configuration to be overwritten by the recipe's own copy of the necessary repository resources.

I also took the liberty to switch DSE repositories to https, as the use of 'apt-transport-https' lead me to believe that was intended.

Unfortunately, this is was not tested against the specs as I get `Failure/Error: expect(chef_run).to create_group('cassandra').with(members: ['cassandra'])`, sorry.

Thanks for your time