### PR TITLE
Allow configuration of Heap Dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:cas_contention_timeout_in_ms]` How long a coordinator should continue to retry a CAS operation that contends with other proposals for the same row (default: 1000)
  * `node[:cassandra][:batch_size_warn_threshold_in_kb]` Log WARN on any batch size exceeding this value. 5kb per batch by default (default: 5)
  * `node[:cassandra][:batchlog_replay_throttle_in_kb]` Maximum throttle in KBs per second, total. This will be reduced proportionally to the number of nodes in the cluster (default: 1024)
+ * `node[:cassandra][:heap_dump]` -XX:+HeapDumpOnOutOfMemoryError JVM parameter (default: true)
+ * `node[:cassandra][:heap_dump_dir]` Directory where heap dumps will be placed (default: nil, which will use cwd)
+
 
 Attributes for fine tuning CMS/ParNew, the GC algorithm recommended for Cassandra deployments:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -89,8 +89,8 @@ default['cassandra']['start_native_transport'] = true
 default['cassandra']['start_rpc'] = true
 default['cassandra']['rpc_keepalive'] = true
 default['cassandra']['rpc_server_type'] = 'sync' # 'sync' or 'hsha'
-default['cassandra']['rpc_min_threads'] = 16  
-default['cassandra']['rpc_max_threads'] = 2048 
+default['cassandra']['rpc_min_threads'] = 16
+default['cassandra']['rpc_max_threads'] = 2048
 
 default['cassandra']['thrift_framed_transport_size_in_mb'] = 15
 default['cassandra']['thrift_max_message_length_in_mb'] = 16
@@ -134,6 +134,10 @@ default['cassandra']['metrics_reporter']['jar_url'] = 'http://search.maven.org/r
 default['cassandra']['metrics_reporter']['sha256sum'] = '6b4042aabf532229f8678b8dcd34e2215d94a683270898c162175b1b13d87de4'
 default['cassandra']['metrics_reporter']['jar_name'] = 'metrics-graphite-2.2.0.jar'
 default['cassandra']['metrics_reporter']['config'] = {} # should be a hash of relevant config
+
+#Heap Dump
+default['cassandra']['heap_dump'] = true
+default['cassandra']['heap_dump_dir'] = nil
 
 # GC tuning options
 default['cassandra']['gc_survivor_ratio'] = 8

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -228,8 +228,13 @@ JVM_OPTS="$JVM_OPTS -Xmn<%= node['cassandra']['jvm']['xmn'] %>"
 JVM_OPTS="$JVM_OPTS -Xmn${HEAP_NEWSIZE}"
 <% end -%>
 
+<% if node['cassandra']['heap_dump'] -%>
 JVM_OPTS="$JVM_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+<% end -%>
 
+<% if node['cassandra']['heap_dump_dir'] -%>
+CASSANDRA_HEAPDUMP_DIR=<%= node['cassandra']['heap_dump_dir'] %>
+<% end -%>
 # set jvm HeapDumpPath with CASSANDRA_HEAPDUMP_DIR
 if [ "x$CASSANDRA_HEAPDUMP_DIR" != "x" ]; then
     JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"


### PR DESCRIPTION
When the JVM experiences an `java.lang.OutOfMemoryError ` it allows you to dump
the heap as a .hprof file for later analysis.  The default cassandra-env.sh
enables this behavior and doesn't specify a dump location, which results in
the current directory being used.

This change allows you to disable Heap Dumps or to change the directory into
which dumps are placed.

This change does not affect the cookbook's default behavior.

More details on HeapDump flags are [here](http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html#DebuggingOptions).