### PR TITLE
Set `rpc_max_threads` to use the correct attribute.

### DIFF
--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -405,7 +405,7 @@ rpc_server_type: <%= node['cassandra']['rpc_server_type'] %>
 # rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
 #
 rpc_min_threads: <%= node['cassandra']['rpc_min_threads'] %>
-rpc_max_threads: <%= node['cassandra']['rpc_min_threads'] %>
+rpc_max_threads: <%= node['cassandra']['rpc_max_threads'] %>
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:


### PR DESCRIPTION
This was accidentally introduced in b4ae8899abd419dafa4e0fb70e16005dfec42205