### PR TITLE
Adding tweak to disable Foodcritic faulty rule FC048

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -18,7 +18,7 @@
 #
 
 group node['cassandra']['group'] do
-  system node['cassandra']['system_user']
+  system node['cassandra']['system_user'] # ~FC048
   action :create
 end
 
@@ -26,7 +26,7 @@ user node['cassandra']['user'] do
   comment 'Cassandra Server user'
   gid node['cassandra']['group']
   home node['cassandra']['user_home'] if node['cassandra']['user_home']
-  system node['cassandra']['system_user']
+  system node['cassandra']['system_user'] # ~FC048
   shell '/bin/bash'
   action :create
 end


### PR DESCRIPTION
Foodcritic fails because of faulty rule which tracks "system" attribute as execution and not as attribute.