### PR TITLE
Update JAMM to 0.2.8 for cassandra 2.1+ (CASSANDRA-8209)

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -35,11 +35,11 @@ else
   node.default['cassandra']['log_config_files'] = %w(logback.xml logback-tools.xml)
   node.default['cassandra']['setup_jna'] = false
   node.default['cassandra']['setup_jamm'] = true
-  node.default['cassandra']['jamm_version'] = '0.2.6'
+  node.default['cassandra']['jamm_version'] = '0.2.8'
   node.default['cassandra']['cassandra_old_version_20'] = false
   node.default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/jbellis/jamm/#{node.attribute['cassandra']['jamm_version']}"
   node.default['cassandra']['jamm']['jar_name'] = "jamm-#{node.attribute['cassandra']['jamm_version']}.jar"
-  node.default['cassandra']['jamm']['sha256sum'] = 'c9577bba0321eeb5358fdea29634cbf124ae3742e80d729f3bd98e0e23726dbf'
+  node.default['cassandra']['jamm']['sha256sum'] = '79d44f1b911a603f0a249aa59ad6ea22aac9c9b211719e86f357646cdf361a42'
 end
 
 node.default['cassandra']['installation_dir'] = '/usr/share/cassandra'


### PR DESCRIPTION
Moved to JAMM 0.2.8 because of CASSANDRA-8209:
C* does not start because org.github.jamm.MemoryMeter.ignoreKnownSingletons() is needed and was added after 0.2.6)

