### PR TITLE
Allow non-latest versions

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -84,6 +84,10 @@ when 'debian'
     # This is necessary because apt gets very confused by the fact that the
     # latest package available for cassandra is 2.x while you're trying to
     # install dsc12 which requests 1.2.x.
+    apt_preference node['cassandra']['package_name'] do
+      pin "version #{node['cassandra']['version']}-#{node['cassandra']['release']}"
+      pin_priority '700'
+    end
     apt_preference 'cassandra' do
       pin "version #{node['cassandra']['version']}"
       pin_priority '700'
@@ -91,7 +95,6 @@ when 'debian'
   end
 
   package node['cassandra']['package_name'] do
-    # version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
     action :install
     # giving C* some time to start up
     notifies :run, 'ruby_block[sleep30s]', :immediately


### PR DESCRIPTION
When running the cookbook with default attributes, the `cassandra::datastax` recipe fails due to a version conflict between dscxx and cassandra:
```
[2015-02-18T23:55:47+00:00] INFO: Processing apt_package[dsc20] action install (cassandra::datastax line 93)


    ================================================================================
    Error executing action `install` on resource 'apt_package[dsc20]'
    ================================================================================

           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------

       Expected process to exit with [0], but received '100'
           ---- Begin output of apt-get -q -y install dsc20=2.0.12-1 ----
           STDOUT: Reading package lists...
           Building dependency tree...
           Reading state information...
           Some packages could not be installed. This may mean that you have
           requested an impossible situation or if you are using the unstable
           distribution that some required packages have not yet been created

       or been moved out of Incoming.
           The following information may help to resolve the situation:

           The following packages have unmet dependencies:
            dsc20 : Depends: cassandra (= 2.0.12) but 2.0.11 is to be installed
           STDERR: E: Unable to correct problems, you have held broken packages.
           ---- End output of apt-get -q -y install dsc20=2.0.12-1 ----
           Ran apt-get -q -y install dsc20=2.0.12-1 returned 100


           Resource Declaration:
           ---------------------

       # In /tmp/kitchen/cache/cookbooks/cassandra/recipes/datastax.rb

            93:   package node['cassandra']['package_name'] do
            94:     # version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
            95:     action :install
            96:     # giving C* some time to start up
            97:     notifies :run, 'ruby_block[sleep30s]', :immediately
            98:     notifies :run, 'execute[set_cluster_name]', :immediately
            99:   end

           100:

           Compiled Resource:

           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/cassandra/recipes/datastax.rb:93:in `from_file'


           apt_package("dsc20") do
             action [:install]
             retries 0
             retry_delay 2

             default_guard_interpreter :default
             package_name "dsc20"
             version "2.0.12-1"
             timeout 900
             declared_type :package

             cookbook_name "cassandra"
             recipe_name "datastax"
           end


[2015-02-18T23:55:48+00:00] INFO: Running queued delayed notifications before re-raising exception
```
This change adds a version preference for dsc/dse that's equal to the corresponding Cassandra version.  That allows the recipe to install non-latest versions of dsc packages.