### PR TITLE
Use https for the apt repo and key

### DIFF
--- a/attributes/datastax.rb
+++ b/attributes/datastax.rb
@@ -12,8 +12,8 @@ default['cassandra']['yum']['options'] = ''
 default['cassandra']['yum']['action'] = :create
 
 default['cassandra']['apt']['repo'] = 'datastax'
-default['cassandra']['apt']['uri'] = 'http://debian.datastax.com/community' # for dsc (not dse)
+default['cassandra']['apt']['uri'] = 'https://debian.datastax.com/community/' # for dsc (not dse)
 default['cassandra']['apt']['distribution'] = 'stable'
 default['cassandra']['apt']['components'] = %w(main)
-default['cassandra']['apt']['repo_key'] = 'http://debian.datastax.com/debian/repo_key'
+default['cassandra']['apt']['repo_key'] = 'https://debian.datastax.com/debian/repo_key'
 default['cassandra']['apt']['action'] = :add


### PR DESCRIPTION
Some small quirk of the apt cookbook is causing the `cassandra::datastax` and `cassandra::opscenter_agent_datastax` to flip the apt repo back and forth between http and https:

```
Recipe: cassandra::datastax
  * apt_repository[datastax] action add
    * remote_file[/var/chef/cache/repo_key] action create (up to date)
    * execute[install-key repo_key] action run (skipped due to not_if)
    * file[/var/lib/apt/periodic/update-success-stamp] action nothing (skipped due to action :nothing)
    * execute[apt-cache gencaches] action nothing (skipped due to action :nothing)
    * execute[apt-get update] action nothing (skipped due to action :nothing)
    * file[/etc/apt/sources.list.d/datastax.list] action create
      - update content in file /etc/apt/sources.list.d/datastax.list from dc0fea to 244e7c
      --- /etc/apt/sources.list.d/datastax.list	2015-02-19 16:52:00.924819138 +0000
      +++ /tmp/.datastax.list20150219-481-1qsg36e	2015-02-19 17:10:13.167609702 +0000
      @@ -1,2 +1,2 @@
      -deb     https://debian.datastax.com/community stable main
      +deb     http://debian.datastax.com/community stable main
    * file[/var/lib/apt/periodic/update-success-stamp] action delete
      - delete file /var/lib/apt/periodic/update-success-stamp
    * execute[apt-get update] action run
      - execute apt-get update -o Dir::Etc::sourcelist='sources.list.d/datastax.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
```

```
Recipe: cassandra::opscenter_agent_datastax
  * apt_repository[datastax] action add
    * remote_file[/var/chef/cache/repo_key] action create (up to date)
    * execute[install-key repo_key] action run (skipped due to not_if)
    * file[/var/lib/apt/periodic/update-success-stamp] action nothing (skipped due to action :nothing)
    * execute[apt-cache gencaches] action nothing (skipped due to action :nothing)
    * execute[apt-get update] action nothing (skipped due to action :nothing)
    * file[/etc/apt/sources.list.d/datastax.list] action create
      - update content in file /etc/apt/sources.list.d/datastax.list from 244e7c to dc0fea
      --- /etc/apt/sources.list.d/datastax.list	2015-02-19 17:10:13.167609702 +0000
      +++ /tmp/.datastax.list20150219-481-q5iuq2	2015-02-19 17:10:23.003384137 +0000
      @@ -1,2 +1,2 @@
      -deb     http://debian.datastax.com/community stable main
      +deb     https://debian.datastax.com/community stable main
    * file[/var/lib/apt/periodic/update-success-stamp] action delete
      - delete file /var/lib/apt/periodic/update-success-stamp
    * execute[apt-get update] action run
      - execute apt-get update -o Dir::Etc::sourcelist='sources.list.d/datastax.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * file[/var/lib/apt/periodic/update-success-stamp] action delete
      - delete file /var/lib/apt/periodic/update-success-stamp
    * execute[apt-get update] action run
      - execute apt-get update -o Dir::Etc::sourcelist='sources.list.d/datastax.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
    * execute[apt-cache gencaches] action run
      - execute apt-cache gencaches
```

The easiest way to fix this is to just use https with the debian site.