### PR TITLE
Ignore config files during Cassandra upgrade

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -96,6 +96,7 @@ when 'debian'
 
   package node['cassandra']['package_name'] do
     action :install
+    options '--force-yes -o Dpkg::Options::="--force-confold"'
     # giving C* some time to start up
     notifies :run, 'ruby_block[sleep30s]', :immediately
     notifies :run, 'execute[set_cluster_name]', :immediately


### PR DESCRIPTION
When upgrading cassandra by changing the attribute, an error is thrown (below) when the cassandra package tries to overwrite `cassandra.yaml` and `cassandra-env.sh`.  Since we overwrite those files ourselves, this keeps the latest versions of the files.  This option is pretty common in other cookbooks: https://github.com/acidlabs/chef-rails/blob/master/site-cookbooks/nginx/recipes/default.rb#L16

```
==> default: ================================================================================
==> default: Error executing action `install` on resource 'package[dsc20]'
==> default: ================================================================================
==> default: 
==> default: Mixlib::ShellOut::ShellCommandFailed
==> default: ------------------------------------
==> default: Expected process to exit with [0], but received '100'
==> default: ---- Begin output of apt-get -q -y install dsc20=2.0.12-1 ----
==> default: STDOUT: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following packages were automatically installed and are no longer required:
==> default:   jsvc libnss3 libevent-extra-2.0-5 liblcms2-2 java-common icedtea-6-jre-cacao
==> default:   openjdk-6-jre-lib openjdk-6-jre-headless libevent-openssl-2.0-5
==> default:   icedtea-6-jre-jamvm tzdata-java libevent-pthreads-2.0-5 libnspr4
==> default:   libcommons-daemon-java ca-certificates-java libevent-core-2.0-5 libnss3-1d
==> default: Use 'apt-get autoremove' to remove them.
==> default: The following extra packages will be installed:
==> default:   cassandra
==> default: The following packages will be REMOVED:
==> default:   dsc12
==> default: The following NEW packages will be installed:
==> default:   dsc20
==> default: 
==> default: The following packages will be upgraded:
==> default:   cassandra
==> default: 
==> default: 1 upgraded, 1 newly installed, 1 to remove and 130 not upgraded.
==> default: Need to get 14.5 MB of archives.
==> default: After this operation, 868 kB of additional disk space will be used.
==> default: Get:1 https://debian.datastax.com/community/ stable/main cassandra all 2.0.12 [14.5 MB]
==> default: Get:2 https://debian.datastax.com/community/ stable/main dsc20 all 2.0.12-1 [1,306 B]
==> default: Fetched 14.5 MB in 7s (1,932 kB/s)
==> default: (Reading database ... 142338 files and directories currently installed.)
==> default: Removing dsc12 ...
==> default: (Reading database ... 142335 files and directories currently installed.)
==> default: Preparing to replace cassandra 1.2.19 (using .../cassandra_2.0.12_all.deb) ...
==> default: Unpacking replacement cassandra ...
==> default: 
==> default: Selecting previously unselected package dsc20.
==> default: Unpacking dsc20 (from .../dsc20_2.0.12-1_all.deb) ...
==> default: Processing triggers for python-support ...
==> default: Processing triggers for ureadahead ...
==> default: Setting up cassandra (2.0.12) ...
==> default: STDERR: Configuration file `/etc/cassandra/cassandra-env.sh'
==> default:  ==> Modified (by you or by a script) since installation.
==> default: 
==> default:  ==> Package distributor has shipped an updated version.
==> default:    What would you like to do about it ?  Your options are:
==> default:     Y or I  : install the package maintainer's version
==> default:     N or O  : keep your currently-installed version
==> default:       D     : show the differences between the versions
==> default:       Z     : start a shell to examine the situation
==> default:  The default action is to keep your current version.
==> default: *** cassandra-env.sh (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing cassandra (--configure):
==> default:  EOF on stdin at conffile prompt
==> default: dpkg: dependency problems prevent configuration of dsc20:
==> default:  dsc20 depends on cassandra (= 2.0.12); however:
==> default:   Package cassandra is not configured yet.
==> default: dpkg: error processing dsc20 (--configure):
==> default:  dependency problems - leaving unconfigured
==> default: 
==> default: No apport report written because the error message indicates its a followup error from a previous failure.
==> default: Errors were encountered while processing:
==> default:  cassandra
==> default:  dsc20
==> default: E: Sub-process /usr/bin/dpkg returned an error code (1)
==> default: ---- End output of apt-get -q -y install dsc20=2.0.12-1 ----
==> default: 
==> default: Ran apt-get -q -y install dsc20=2.0.12-1 returned 100
==> default: 
==> default: Resource Declaration:
==> default: ---------------------
==> default: # In /tmp/vagrant-chef-3/chef-solo-1/cookbooks/cassandra/recipes/datastax.rb
==> default: 
==> default: 
==> default:  97:   package node['cassandra']['package_name'] do
==> default:  98:     action :install
==> default:  99:     # giving C* some time to start up
==> default: 
==> default: 100:     notifies :run, 'ruby_block[sleep30s]', :immediately
==> default: 101:     notifies :run, 'execute[set_cluster_name]', :immediately
==> default: 102:   end
==> default: 103: 
==> default: 
==> default: Compiled Resource:
==> default: ------------------
==> default: # Declared in /tmp/vagrant-chef-3/chef-solo-1/cookbooks/cassandra/recipes/datastax.rb:97:in `from_file'
==> default: 
==> default: package("dsc20") do
==> default:   action [:install]
==> default:   retries 0
==> default:   retry_delay 2
==> default:   guard_interpreter :default
==> default:   package_name "dsc20"
==> default:   version "2.0.12-1"
==> default:   timeout 900
==> default:   cookbook_name :cassandra
==> default:   recipe_name "datastax"
==> default: end
==> default: 
==> default: 
```