### PR TITLE
Fix/create chef search attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ suites:
         opscenter:
           agent:
             server_host: 0.0.0.0
+            use_chef_search: false
     run_list:
       - recipe[cassandra::default]
       - recipe[cassandra::opscenter_agent_datastax]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:opscenter][:agent][:binary_name]` (default: `opscenter-agent`) Introduced since Datastax changed agent binary name from opscenter-agent to datastax-agent. **Make sure to set it right if you are updating to 4.0.2**
  * `node[:cassandra][:opscenter][:agent][:server_host]` (default: "" ). If left empty, will use search to get IP by opscenter `server_role` role.
  * `node[:cassandra][:opscenter][:agent][:server_role]` (default: `opscenter_server`). Will be use for opscenter server IP lookup if `:server_host` is not set.
+ * `node[:cassandra][:opscenter][:agent][:use_chef_search]` (default: `true`). Determines whether chef search will be used for locating the data agent server.
  * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `true`)
 
 #### DataStax Ops Center Agent Datastax attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -214,5 +214,6 @@ default['cassandra']['opscenter']['agent']['install_dir'] = '/opt'
 default['cassandra']['opscenter']['agent']['install_folder_name'] = 'opscenter_agent'
 default['cassandra']['opscenter']['agent']['binary_name'] = 'opscenter-agent'
 default['cassandra']['opscenter']['agent']['server_host'] = nil # if nil, will use search to get IP by server role
+default['cassandra']['opscenter']['agent']['use_chef_search'] = true
 default['cassandra']['opscenter']['agent']['server_role'] = 'opscenter_server'
 default['cassandra']['opscenter']['agent']['use_ssl'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'michael@clojurewerkz.org'
 license 'Apache 2.0'
 description 'Installs/configures Apache Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.10.0'
+version '2.10.1'
 depends 'java'
 depends 'ulimit'
 depends 'apt'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'michael@clojurewerkz.org'
 license 'Apache 2.0'
 description 'Installs/configures Apache Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.10.1'
+version '2.10.0'
 depends 'java'
 depends 'ulimit'
 depends 'apt'

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -22,7 +22,7 @@ include_recipe 'cassandra::repositories'
 
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 
-unless server_ip && Chef::Config[:solo]
+unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
   search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
   if !search_results.empty?
     server_ip = search_results[0]['ipaddress']

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -23,12 +23,16 @@ include_recipe 'cassandra::repositories'
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 
 unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
-  search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
-  if !search_results.empty?
-    server_ip = search_results[0]['ipaddress']
-  else
-    return # Continue until opscenter will come up
+  
+  unless Chef::Config[:solo]
+    search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
+    if !search_results.empty?
+      server_ip = search_results[0]['ipaddress']
+    else
+      return # Continue until opscenter will come up
+    end
   end
+    
 end
 
 case node['platform_family']

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -23,7 +23,7 @@ include_recipe 'cassandra::repositories'
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 
 unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
-  
+
   unless Chef::Config[:solo]
     search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
     if !search_results.empty?
@@ -32,7 +32,7 @@ unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
       return # Continue until opscenter will come up
     end
   end
-    
+
 end
 
 case node['platform_family']

--- a/recipes/opscenter_agent_tarball.rb
+++ b/recipes/opscenter_agent_tarball.rb
@@ -28,12 +28,16 @@ end
 
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
-  search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
-  if !search_results.empty?
-    server_ip = search_results[0]['ipaddress']
-  else
-    return # Continue until opscenter will come up
+  
+  unless Chef::Config[:solo]
+    search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
+    if !search_results.empty?
+      server_ip = search_results[0]['ipaddress']
+    else
+      return # Continue until opscenter will come up
+    end
   end
+    
 end
 
 agent_dir = ::File.join(node['cassandra']['opscenter']['agent']['install_dir'], node['cassandra']['opscenter']['agent']['install_folder_name'])

--- a/recipes/opscenter_agent_tarball.rb
+++ b/recipes/opscenter_agent_tarball.rb
@@ -28,7 +28,7 @@ end
 
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
 unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
-  
+
   unless Chef::Config[:solo]
     search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
     if !search_results.empty?
@@ -37,7 +37,7 @@ unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
       return # Continue until opscenter will come up
     end
   end
-    
+
 end
 
 agent_dir = ::File.join(node['cassandra']['opscenter']['agent']['install_dir'], node['cassandra']['opscenter']['agent']['install_folder_name'])

--- a/recipes/opscenter_agent_tarball.rb
+++ b/recipes/opscenter_agent_tarball.rb
@@ -27,7 +27,7 @@ ark node['cassandra']['opscenter']['agent']['install_folder_name'] do
 end
 
 server_ip = node['cassandra']['opscenter']['agent']['server_host']
-unless server_ip && Chef::Config[:solo]
+unless server_ip && node['cassandra']['opscenter']['agent']['use_chef_search']
   search_results = search(:node, "roles:#{node['cassandra']['opscenter']['agent']['server_role']}")
   if !search_results.empty?
     server_ip = search_results[0]['ipaddress']


### PR DESCRIPTION
Making it so that the use of chef search is more easily controlled by users of this cookbook. We need to do this because we don't use chef search, without this change, we'd need to write our own cookbook for the datastax agent install.