### PR TITLE
Fix datastax-agent configuration ownership

### DIFF
--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -51,8 +51,8 @@ end
 
 template '/var/lib/datastax-agent/conf/address.yaml' do
   mode 0644
-  owner 'opscenter-agent'
-  group 'opscenter-agent'
+  owner node['cassandra']['user']
+  group node['cassandra']['group']
   source 'opscenter-agent.conf.erb'
   variables(:server_ip => server_ip)
   notifies :restart, 'service[datastax-agent]'


### PR DESCRIPTION
In datastax-agent 5.1.0, the agent begins running as the cassandra user.  This changes ownership of address.yaml to the cassandra user to fix #175.
This will change the ownership of address.yaml on nodes with datastax-agent < 5.1.0, but the permissions are loose enough that it should still work for the older agent.