### PR TITLE
Add support for '-Dcassandra.boot_without_jna=true' for low-memory C*.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:notify_restart]` (default: false): notify Cassandra service restart upon resource update
   * Setting `node[:cassandra][:notify_restart]` to true will restart Cassandra service upon resource change
  * `node[:cassandra][:setup_jna]` (default: true): installs jna.jar
+ * `node[:cassandra][:skip_jna]` (default: false): (2.1.0 and up only) removes jna.jar, adding '-Dcassandra.boot_without_jna=true' for low-memory C* installations 
  * `node[:cassandra][:pid_dir]` (default: true): pid directory for Cassandra node process for `cassandra::tarball` recipe
  * `node[:cassandra][:dir_mode]` (default: 0755): default permission set for Cassandra node directory / files
  * `node[:cassandra][:service_action]` (default: [:enable, :start]): default service actions for the service
@@ -229,7 +230,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:heap_dump]` -XX:+HeapDumpOnOutOfMemoryError JVM parameter (default: true)
  * `node[:cassandra][:heap_dump_dir]` Directory where heap dumps will be placed (default: nil, which will use cwd)
 
-Attributes used to define JBOD functionality 
+Attributes used to define JBOD functionality
 
 * `default['cassandra']['jbod']['slices']` - defines the number of jbod slices while each represents data directory. By default disables with nil.  
 * `default['cassandra']['jbod']['dir_name_prefix']` - defines the data directory prefix
@@ -276,4 +277,3 @@ Released under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/michaelklishin/cassandra-chef-cookbook/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -34,6 +34,7 @@ else
   # >= 2.1 Version
   node.default['cassandra']['log_config_files'] = %w(logback.xml logback-tools.xml)
   node.default['cassandra']['setup_jna'] = false
+  node.default['cassandra']['skip_jna'] = false
   node.default['cassandra']['setup_jamm'] = true
   node.default['cassandra']['jamm_version'] = '0.2.8'
   node.default['cassandra']['cassandra_old_version_20'] = false
@@ -239,6 +240,12 @@ link "#{node['cassandra']['lib_dir']}/jna.jar" do
   to '/usr/share/java/jna.jar'
   notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
   only_if { node['cassandra']['setup_jna'] }
+end
+
+file "#{node['cassandra']['lib_dir']}/jna.jar" do
+  action :delete
+  notifies :restart, "service[cassandra]", :delayed if node['cassandra']['notify_restart']
+  only_if { node['cassandra']['skip_jna'] }
 end
 
 remote_file "/usr/share/java/#{node['cassandra']['jamm']['jar_name']}" do

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -309,6 +309,10 @@ JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<%= node['cassandra']['jmx_server
 JVM_OPTS="$JVM_OPTS -Dcassandra.metricsReporterConfigFile=cassandra-metrics.yaml"
 <% end %>
 
+<% if node['cassandra']['skip_jna'] %>
+JVM_OPTS="$JVM_OPTS -Dcassandra.boot_without_jna=true"
+<% end %>
+
 #
 # see
 # https://blogs.oracle.com/jmxetc/entry/troubleshooting_connection_problems_in_jconsole


### PR DESCRIPTION
This patch supports running versions >= 2.1.0 withouth JNA installed in
order to support running in low-memory environments like Vagrant
containers, embedded systems and the like.

The underlying isssue is that JNA attempts to Malloc ~ 1024mb at minimum
on startup. For those of us who like to launch multi-DC clusters using
this recipe from a Vagrantfile, that is a deal killer.

See https://issues.apache.org/jira/browse/CASSANDRA-6575 and 
https://github.com/pcmanus/ccm/issues/97 for more info.

This patch modifies the cookcook by:

- adding '-Dcassandra.boot_without_jna=true' option to cassandra-env.sh
- removing the jna.jar from the lib directory from the recipe if enabled
- adding brief description in the readme

Fixes issue #178