### PR TITLE
add opscenter agent config dir attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -219,4 +219,3 @@ default['cassandra']['opscenter']['agent']['use_chef_search'] = true
 default['cassandra']['opscenter']['agent']['server_role'] = 'opscenter_server'
 default['cassandra']['opscenter']['agent']['use_ssl'] = true
 default['cassandra']['opscenter']['agent']['conf_dir'] = '/var/lib/datastax-agent/conf'
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -218,3 +218,5 @@ default['cassandra']['opscenter']['agent']['server_host'] = nil # if nil, will u
 default['cassandra']['opscenter']['agent']['use_chef_search'] = true
 default['cassandra']['opscenter']['agent']['server_role'] = 'opscenter_server'
 default['cassandra']['opscenter']['agent']['use_ssl'] = true
+default['cassandra']['opscenter']['agent']['conf_dir'] = '/var/lib/datastax-agent/conf'
+

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -49,7 +49,7 @@ service 'datastax-agent' do
   action [:enable, :start]
 end
 
-template '/var/lib/datastax-agent/conf/address.yaml' do
+template ::File.join(node['cassandra']['opscenter']['agent']['conf_dir'], 'address.yaml') do
   mode 0644
   owner node['cassandra']['user']
   group node['cassandra']['group']


### PR DESCRIPTION
I have added an attribute for the config directory so it can be overridden if needed. 