### PR TITLE
Always install package 'apt-transport-https' for debian

### DIFF
--- a/recipes/repositories.rb
+++ b/recipes/repositories.rb
@@ -28,7 +28,7 @@ end
 
 case node['platform_family']
 when 'debian'
-  package 'apt-transport-https' if node['cassandra']['dse']
+  package 'apt-transport-https'
 
   apt_repository node['cassandra']['apt']['repo'] do
     if node['cassandra']['dse']


### PR DESCRIPTION
We need to install the ```apt-transport-https``` package (for Ubuntu at least), otherwise we cannot use https URLs at ```node['cassandra']['apt']['uri']``` (which is the default one now).