### PR TITLE
Changed log_config_files and jamm related attibutes to be defined at …

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Cassandra 2.x requires JDK 7+, Oracle JDK is recommended.
 
 ## Recipes
 
-Two provided recipes are `cassandra::tarball` and `cassandra::datastax`. The former uses official tarball
+The main recipe is `cassandra::default` which together with the `node[:cassandra][:install_method]` attribute
+will be responsible for including the proper installation recipe.
+
+Two actual installation recipes are `cassandra::tarball` and `cassandra::datastax`. The former uses official tarball
 and thus can be used to provision any specific version.
 
 The latter uses DataStax repository via packages. You can install different versions (ex. dsc20 for v2.0) available in the repository by altering `:package_name` attribute (`dsc20` by default).
@@ -56,7 +59,7 @@ Attribute `node[:cassandra][:setup_jna]` will install the jna.jar in the
 documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassandra/install/installJnaDeb.html).
 
 ## Core Attributes
-
+ * `node[:cassandra][:install_method]` (default: datastax): The installation method to use (either 'datastax' or 'tarball').
  * `node[:cassandra][:cluster_name]` (default: none): Name of the cluster to create. This is required.
  * `node[:cassandra][:version]` (default: a recent patch version): version to provision
  * `node[:cassandra][:tarball][:url]` and `node[:cassandra][:tarball][:md5]` specify tarball URL and MD5 check sum used by the `cassandra::tarball` recipe.

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -23,24 +23,14 @@ case node['cassandra']['version']
 # Submit an issue if jamm version is not correct for 0.x or 1.x version
 when /^0\./, /^1\./, /^2\.0/
   # < 2.1 Versions
-  node.default['cassandra']['log_config_files'] = %w(log4j-server.properties)
-  node.default['cassandra']['jamm_version'] = '0.2.5'
   node.default['cassandra']['setup_jna'] = true
   node.default['cassandra']['cassandra_old_version_20'] = true
-  node.default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/stephenc/jamm/#{node.attribute['cassandra']['jamm_version']}"
-  node.default['cassandra']['jamm']['jar_name'] = "jamm-#{node.attribute['cassandra']['jamm_version']}.jar"
-  node.default['cassandra']['jamm']['sha256sum'] = 'e3dd1200c691f8950f51a50424dd133fb834ab2ce9920b05aa98024550601cc5'
 else
   # >= 2.1 Version
-  node.default['cassandra']['log_config_files'] = %w(logback.xml logback-tools.xml)
   node.default['cassandra']['setup_jna'] = false
   node.default['cassandra']['skip_jna'] = false
   node.default['cassandra']['setup_jamm'] = true
-  node.default['cassandra']['jamm_version'] = '0.2.8'
   node.default['cassandra']['cassandra_old_version_20'] = false
-  node.default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/jbellis/jamm/#{node.attribute['cassandra']['jamm_version']}"
-  node.default['cassandra']['jamm']['jar_name'] = "jamm-#{node.attribute['cassandra']['jamm_version']}.jar"
-  node.default['cassandra']['jamm']['sha256sum'] = '79d44f1b911a603f0a249aa59ad6ea22aac9c9b211719e86f357646cdf361a42'
 end
 
 node.default['cassandra']['installation_dir'] = '/usr/share/cassandra'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,22 @@
 # limitations under the License.
 #
 
+case node['cassandra']['version']
+# Submit an issue if jamm version is not correct for 0.x or 1.x version
+when /^0\./, /^1\./, /^2\.0/
+  # < 2.1 Versions
+  node.default['cassandra']['log_config_files'] = %w(log4j-server.properties)
+  node.default['cassandra']['jamm_version'] = '0.2.5'
+  node.default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/stephenc/jamm/#{node.attribute['cassandra']['jamm_version']}"
+  node.default['cassandra']['jamm']['jar_name'] = "jamm-#{node.attribute['cassandra']['jamm_version']}.jar"
+  node.default['cassandra']['jamm']['sha256sum'] = 'e3dd1200c691f8950f51a50424dd133fb834ab2ce9920b05aa98024550601cc5'
+else
+  # >= 2.1 Version
+  node.default['cassandra']['log_config_files'] = %w(logback.xml logback-tools.xml)
+  node.default['cassandra']['jamm_version'] = '0.2.8'
+  node.default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/jbellis/jamm/#{node.attribute['cassandra']['jamm_version']}"
+  node.default['cassandra']['jamm']['jar_name'] = "jamm-#{node.attribute['cassandra']['jamm_version']}.jar"
+  node.default['cassandra']['jamm']['sha256sum'] = '79d44f1b911a603f0a249aa59ad6ea22aac9c9b211719e86f357646cdf361a42'
+end
+
 include_recipe 'cassandra::datastax'


### PR DESCRIPTION
…default recipe instead of datastax one.

**Together with #190 and #191** I believe this will fix #184.
If all of them are accepted, please merge the other two PRs first and then if necessary I'll update this one.

Anyway, every PR can be merged independently while maintaining BC.