### PR TITLE
Create data dir explicitly with proper permissions

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -97,6 +97,7 @@ end
  node['cassandra']['pid_dir'],
  node['cassandra']['lib_dir'],
  node['cassandra']['root_dir'],
+ node['cassandra']['data_dir'],
  node['cassandra']['conf_dir']
 ].each do |dir|
   directory dir do


### PR DESCRIPTION
Please have a look at this one liner which adds `node['cassandra']['data_dir']` to the list of directories created by recipe.

Motivation: even though cassandra can create `data_dir` during bootstrap without any help from the recipe, it may fail to do so if that directory is configured to reside outside of `root_dir` subtree. Such use case may arise when data and commit logs are put on different volumes, and `data_dir`'s parent is owned by root.
