### PR TITLE
Properly set FD_LIMIT in sysv init when installing from package

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,15 +71,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision :chef_solo do |chef|
     chef.json = {
-      mysql: {
-        server_root_password: 'rootpass',
-        server_debian_password: 'debpass',
-        server_repl_password: 'replpass'
+      cassandra: {
+        cluster_name: 'vagrant-test'
       }
     }
 
     chef.run_list = [
-        "recipe[cassandra::default]"
+        "recipe[cassandra-dse::default]"
     ]
   end
 end


### PR DESCRIPTION
The `default['cassandra']['limits']['nofile']` attribute is not used when
installing from a package on Debian/Ubuntu. This change uses Chef's
FileEdit utility to replace the existing value with the value specified
in the attribute.

Tests pass with `rake`. This has no impact on CentOS 6.5 as it already respects the attribute and it's not defined in `/etc/init.d/cassandra`. I tested on Ubuntu 11.04, 12.04, and 14.04 and verified that the `FD_LIMIT` variable is modified as expected.

Thanks for the fantastic coobook!