### PR TITLE
Customconfig

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -46,16 +46,6 @@ end
   end
 end
 
-%w(cassandra.yaml cassandra-env.sh).each do |f|
-  template ::File.join(node['cassandra']['conf_dir'], f) do
-    source "#{f}.erb"
-    owner node['cassandra']['user']
-    group node['cassandra']['group']
-    mode 0644
-    notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
-  end
-end
-
 node['cassandra']['log_config_files'].each do |f|
   template ::File.join(node['cassandra']['conf_dir'], f) do
     cookbook node['cassandra']['templates_cookbook']

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -38,6 +38,7 @@ end
 # configuration files
 %w(cassandra.yaml cassandra-env.sh).each do |f|
   template ::File.join(node['cassandra']['conf_dir'], f) do
+    cookbook node['cassandra']['templates_cookbook']
     source "#{f}.erb"
     owner node['cassandra']['user']
     group node['cassandra']['group']


### PR DESCRIPTION
* delete duplicate declaration
* use `template_cookbook` to make it possible to externalize the source of config files, same as for `cassandra-metrics.yaml` and others