### PR TITLE
Add Priam javaagent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:heap_dump]` -XX:+HeapDumpOnOutOfMemoryError JVM parameter (default: true)
  * `node[:cassandra][:heap_dump_dir]` Directory where heap dumps will be placed (default: nil, which will use cwd)
  * `node[:cassandra][:vnodes]` enable vnodes. (default: true)
- 
+
  For the complete set of supported attributes, please consult [the source](https://github.com/michaelklishin/cassandra-chef-cookbook/tree/master/attributes).
 
 Attributes used to define JBOD functionality
@@ -274,6 +274,13 @@ Descriptions for these JVM parameters can be found [here](http://www.oracle.com/
  *  `node[:cassandra][:jna][:jar_name]` The name of the jar to download from the base url. (default: jna.jar)
  *  `node[:cassandra][:jna][:sha256sum]` The SHA-256 checksum of the file. If the local jna.jar file matches the checksum, the chef-client will not re-download it. (default: dac270b6441ce24d93a96ddb6e8f93d8df099192738799a6f6fcfc2b2416ca19)
 
+
+### Priam Attributes
+
+ * `node[:cassandra][:setup_priam]` (default: false): install the priam jar file and use it to set java option `-javaagent`, uses the priam version corresponding to the cassandra version
+ * `node[:cassandra][:priam][:sha256sum]` (default: 9fde9a40dc5c538adee54f40fa9027cf3ebb7fd42e3592b3e6fdfe3f7aff81e1): priam lib sha256sum for version `2.2.0`
+ * `node[:cassandra][:priam][:base_url]` (default: priam url on maven.org): priam lib jar url
+ * `node[:cassandra][:priam][:jar_name]` (default: calculated): priam lib jar name
 
 ### Logback Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,11 @@ default['cassandra']['version'] = '2.2.0'
 # not required for later versions
 default['cassandra']['setup_jamm'] = false
 
+default['cassandra']['setup_priam'] = false
+default['cassandra']['priam']['base_url'] = "http://search.maven.org/remotecontent?filepath=com/netflix/priam/priam-cass-extensions/#{node['cassandra']['version']}"
+default['cassandra']['priam']['jar_name'] = "priam-cass-extensions-#{node['cassandra']['version']}.jar"
+default['cassandra']['priam']['sha256sum'] = '9fde9a40dc5c538adee54f40fa9027cf3ebb7fd42e3592b3e6fdfe3f7aff81e1'
+
 default['cassandra']['pid_dir'] = '/var/run/cassandra'
 default['cassandra']['dir_mode'] = '0755'
 default['cassandra']['service_action'] = [:enable, :start]

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -138,6 +138,19 @@ link "#{node['cassandra']['lib_dir']}/#{node['cassandra']['jamm']['jar_name']}" 
   only_if { node['cassandra']['setup_jamm'] }
 end
 
+# setup priam
+remote_file "/usr/share/java/#{node['cassandra']['priam']['jar_name']}" do
+  source "#{node['cassandra']['priam']['base_url']}/#{node['cassandra']['priam']['jar_name']}"
+  checksum node['cassandra']['priam']['sha256sum']
+  only_if { node['cassandra']['setup_priam'] }
+end
+
+link "#{node['cassandra']['lib_dir']}/#{node['cassandra']['priam']['jar_name']}" do
+  to "/usr/share/java/#{node['cassandra']['priam']['jar_name']}"
+  notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
+  only_if { node['cassandra']['setup_priam'] }
+end
+
 # setup jna
 remote_file '/usr/share/java/jna.jar' do
   source "#{node['cassandra']['jna']['base_url']}/#{node['cassandra']['jna']['jar_name']}"

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -188,6 +188,11 @@ then
 fi
 <% end -%>
 
+<% if node['cassandra']['setup_priam'] -%>
+# add the priam cass extensions javaagent
+  JVM_OPTS="$JVM_OPTS -javaagent:$CASSANDRA_HOME/lib/priam-cass-extensions-<%= node['cassandra']['version'] -%>.jar"
+<% end -%>
+
 # some JVMs will fill up their heap when accessed via JMX, see CASSANDRA-6541
 JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
 


### PR DESCRIPTION
Needs to be in the JVM_OPTS for Cassandra. See https://github.com/Netflix/Priam/wiki/Setup. Thanks!