### PR TITLE
Fix cluster_name definition in 4.0.0

### DIFF
--- a/libraries/config_helpers.rb
+++ b/libraries/config_helpers.rb
@@ -60,7 +60,7 @@ def discover_seed_nodes
       q = if search_query = node['cassandra']['seed_discovery']['search_query']
             search_query
           else
-            "chef_environment:#{node.chef_environment} AND role:#{node['cassandra']['seed_discovery']['search_role']} AND cassandra_cluster_name:#{node['cassandra']['cluster_name']}"
+            "chef_environment:#{node.chef_environment} AND role:#{node['cassandra']['seed_discovery']['search_role']} AND cassandra_cluster_name:#{node['cassandra']['config']['cluster_name']}"
           end
       Chef::Log.info("Will discover Cassandra seeds using query '#{q}'")
       xs = search(:node, q).map(&:ipaddress).sort.uniq

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -110,7 +110,7 @@ when 'debian'
   end
 
   execute 'set_cluster_name' do
-    command "/usr/bin/cqlsh -e \"update system.local set cluster_name='#{node['cassandra']['cluster_name']}' where key='local';\"; /usr/bin/nodetool flush;"
+    command "/usr/bin/cqlsh -e \"update system.local set cluster_name='#{node['cassandra']['config']['cluster_name']}' where key='local';\"; /usr/bin/nodetool flush;"
     notifies :restart, 'service[cassandra]', :delayed
     action :nothing
   end


### PR DESCRIPTION
The `cluster_name` definition is broken (incomplete) since the `cassandra['config']` migration. This PR fixes the problem.