### PR TITLE
Fix gc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ Attributes for fine tuning CMS/ParNew, the GC algorithm recommended for Cassandr
 
 Attributes for enabling G1 GC.
 
- * `node[:cassandra][:g1gc]` (default: false)
+ * `node[:cassandra][:jvm][:g1]` (default: false)
 
 Attributes for enabling GC detail/logging.
 
- * `node[:cassandra][:gcdetail]` (default: false)
+ * `node[:cassandra][:jvm][:gcdetail]` (default: false)
 
 Descriptions for these JVM parameters can be found [here](http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html#PerformanceTuning) and [here](http://www.oracle.com/technetwork/java/javase/gc-tuning-6-140523.html#cms.starting_a_cycle).
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -99,8 +99,8 @@ default['cassandra']['heap_dump'] = true
 default['cassandra']['heap_dump_dir'] = nil
 
 # GC tuning options
-default['cassandra']['g1gc'] = false
-default['cassandra']['gcdetail'] = false
+default['cassandra']['jvm']['g1'] = false
+default['cassandra']['jvm']['gcdetail'] = false
 
 default['cassandra']['gc_survivor_ratio'] = 8
 default['cassandra']['gc_max_tenuring_threshold'] = 1

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -280,13 +280,6 @@ JVM_OPTS="$JVM_OPTS -XX:+UseCMSInitiatingOccupancyOnly"
 JVM_OPTS="$JVM_OPTS -XX:+UseTLAB"
 <% end -%>
 
-
-# note: bash evals '1.7.x' as > '1.7' so this is really a >= 1.7 jvm check
-JVM_VERSION_SHORT=$(printf "%.3s" $JVM_VERSION)
-if [ "$JVM_VERSION_SHORT" = "1.7" ] && [ "$JVM_ARCH" = "64-Bit" ] ; then
-    JVM_OPTS="$JVM_OPTS -XX:+UseCondCardMark"
-fi
-
 <% if node[:cassandra][:jvm] && node[:cassandra][:jvm][:gcdetail] -%>
 JVM_OPTS="$JVM_OPTS -XX:+PrintGCDetails"
 JVM_OPTS="$JVM_OPTS -XX:+PrintGCDateStamps"
@@ -322,7 +315,6 @@ JVM_VERSION_SHORT=$(printf "%.3s" $JVM_VERSION)
 if [ "$JVM_VERSION_SHORT" = "1.7" ] && [ "$JVM_ARCH" = "64-Bit" ] ; then
     JVM_OPTS="$JVM_OPTS -XX:+UseCondCardMark"
 fi
-
 
 # uncomment to have Cassandra JVM listen for remote debuggers/profilers on port 1414
 # JVM_OPTS="$JVM_OPTS -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1414"


### PR DESCRIPTION
I had mismatched option names and a duplicated entry in the env.sh template.  This is fixed.