### PR TITLE
User  recipe modification of group did not work

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -34,7 +34,7 @@ user node['cassandra']['user'] do
 end
 
 group "explicity add #{node['cassandra']['user']} to #{node['cassandra']['group']} group" do
-  name node['cassandra']['group']
+  group_name node['cassandra']['group']
   system node['cassandra']['system_user'] # ~FC048
   members [node['cassandra']['user']]
   append true

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -35,6 +35,7 @@ end
 
 group "explicity add #{node['cassandra']['user']} to #{node['cassandra']['group']} group" do
   name node['cassandra']['group']
+  system node['cassandra']['system_user'] # ~FC048
   members [node['cassandra']['user']]
   append true
   only_if { node['cassandra']['setup_user'] }


### PR DESCRIPTION
the group resource wanted the attribute `group_name` not just `name` so it was passing the descriptive name and failing with a misleading error message (`group cassandra does not exist`)

Also passed the `system` attribute in the `:modify` block as well. Not sure if that was really necessary