### PR TITLE
Fixed agent use_ssl configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,13 +350,14 @@ Descriptions for these JVM parameters can be found [here](http://www.oracle.com/
  * `node[:cassandra][:opscenter][:agent][:server_host]` (default: "" ). If left empty, will use search to get IP by opscenter `server_role` role.
  * `node[:cassandra][:opscenter][:agent][:server_role]` (default: `opscenter_server`). Will be use for opscenter server IP lookup if `:server_host` is not set.
  * `node[:cassandra][:opscenter][:agent][:use_chef_search]` (default: `true`). Determines whether chef search will be used for locating the data agent server.
- * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `true`)
+ * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `false`)
 
 #### DataStax Ops Center Agent Datastax attributes
  * `node[:cassandra][:opscenter][:agent][:package_name]` (default: "datastax-agent" ).
  * `node[:cassandra][:opscenter][:agent][:server_host]` (default: "" ). If left empty, will use search to get IP by opscenter `server_role` role.
  * `node[:cassandra][:opscenter][:agent][:server_role]` (default: `opscenter_server`). Will be use for opscenter server IP lookup if `:server_host` is not set.
- * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `true`)
+ * `node[:cassandra][:opscenter][:agent][:use_ssl]` (default: `false`)
+
 
 ### Data Center and Rack Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -128,5 +128,5 @@ default['cassandra']['opscenter']['agent']['binary_name'] = 'opscenter-agent'
 default['cassandra']['opscenter']['agent']['server_host'] = nil # if nil, will use search to get IP by server role
 default['cassandra']['opscenter']['agent']['use_chef_search'] = true
 default['cassandra']['opscenter']['agent']['server_role'] = 'opscenter_server'
-default['cassandra']['opscenter']['agent']['use_ssl'] = true
+default['cassandra']['opscenter']['agent']['use_ssl'] = false
 default['cassandra']['opscenter']['agent']['conf_dir'] = '/var/lib/datastax-agent/conf'

--- a/templates/default/opscenter-agent.conf.erb
+++ b/templates/default/opscenter-agent.conf.erb
@@ -4,6 +4,4 @@
 #
 stomp_interface: "<%= @server_ip %>"
 
-<% unless node['cassandra']['opscenter']['agent']['use_ssl'] %>
-use_ssl: 0
-<% end %>
+use_ssl: <%= node['cassandra']['opscenter']['agent']['use_ssl'] ? "1" : "0" %>

--- a/templates/default/opscenterd.conf.erb
+++ b/templates/default/opscenterd.conf.erb
@@ -12,10 +12,8 @@ port = 7199
 port = <%= node['cassandra']['opscenter']['server']['port'] %>
 interface = <%= node['cassandra']['opscenter']['server']['interface'] %>
 
-<% unless node['cassandra']['opscenter']['agent']['use_ssl'] %>
 [agents]
-use_ssl = false
-<% end %>
+use_ssl = <%= node['cassandra']['opscenter']['agent']['use_ssl'] ? "1" : "0" %>
 
 [logging]
 # level may be TRACE, DEBUG, INFO, WARN, or ERROR


### PR DESCRIPTION
Fixed use_ssl agent configuration.  Prior to this PR use_ssl defaulted to true, but never set use_ssl to "1", it only caused the use_ssl = 0 line to be omitted.  With this PR use_ssl will default to false (this matches documented agent use_ssl default) & also will set use_ssl to 0 when false & use_ssl to 1 when true.

Reference documentation:
http://docs.datastax.com/en/opscenter/5.2/opsc/configure/agentAddressConfiguration.html?scroll=agentAddressConfiguration__use_ssl