### PR TITLE
change default for `local_jmx` to `true`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,17 @@ rake unit
 
 Contributed by Bill Warner.
 
+### Default to localhost-only JMX
+
+The attribute `node[:cassandra][:local_jmx]` defaults to `true` now, making
+JMX listen on localhost only. This is the default since cassandra 2.0.14 and
+2.1.4 and fixes the remote code execution exploit from CVE-2015-0225.
+
+Should you choose to enable remote JMX access by setting this to false, be aware
+that this cookbook currently does not support configuring authentication for JMX,
+so you should limit access to the JMX port by other means, such as firewalling.
+
+
 ## Changes Between 4.0.0 and 4.1.0
 
 ### Priam Support

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:installation_dir]` (default: `/usr/local/cassandra`): installation directory
  * `node[:cassandra][:root_dir]` (default: `/var/lib/cassandra`): data directory root
  * `node[:cassandra][:log_dir]` (default: `/var/log/cassandra`): log directory
- * `node[:cassandra][:local_jmx]` (default: false): bind JMX listener to localhost
+ * `node[:cassandra][:local_jmx]` (default: true): bind JMX listener to localhost
  * `node[:cassandra][:jmx_port]` (default: 7199): port to listen for JMX
  * `node[:cassandra][:notify_restart]` (default: false): notify Cassandra service restart upon resource update
   * Setting `node[:cassandra][:notify_restart]` to true will restart Cassandra service upon resource change

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['cassandra']['pid_dir'] = '/var/run/cassandra'
 default['cassandra']['dir_mode'] = '0755'
 default['cassandra']['service_action'] = [:enable, :start]
 default['cassandra']['jmx_port'] = 7199
-default['cassandra']['local_jmx'] = false
+default['cassandra']['local_jmx'] = true
 
 default['cassandra']['limits']['memlock'] = 'unlimited'
 default['cassandra']['limits']['nofile'] = 48_000

--- a/spec/rendered_templates/cassandra-env.sh
+++ b/spec/rendered_templates/cassandra-env.sh
@@ -287,15 +287,7 @@ JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
 JVM_OPTS="$JVM_OPTS -Dcassandra.metricsReporterConfigFile=cassandra-metrics.yaml"
 
 
-#
-# see
-# https://blogs.oracle.com/jmxetc/entry/troubleshooting_connection_problems_in_jconsole
-# for more on configuring JMX through firewalls, etc. (Short version:
-# get it working with no firewall first.)
-JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
-JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
-JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT -XX:+DisableExplicitGC"
 # see https://issues.apache.org/jira/browse/CASSANDRA-6541
 JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -38,3 +38,10 @@ describe 'cassandra user' do
     it { should have_home_directory '/home/cassandra' }
   end
 end
+
+describe 'jmx port' do
+  describe port(7199) do
+    it { should be_listening.on('127.0.0.1').with('tcp') }
+    it { should not_be_listening.on('0.0.0.0') }
+  end
+end

--- a/test/integration/dsc21/serverspec/default_spec.rb
+++ b/test/integration/dsc21/serverspec/default_spec.rb
@@ -13,3 +13,10 @@ describe 'cassandra' do
     expect(service 'cassandra').to be_enabled
   end
 end
+
+describe 'jmx port' do
+  describe port(7199) do
+    it { should be_listening.on('127.0.0.1').with('tcp') }
+    it { should not_be_listening.on('0.0.0.0') }
+  end
+end

--- a/test/integration/dse/serverspec/dse_spec.rb
+++ b/test/integration/dse/serverspec/dse_spec.rb
@@ -13,3 +13,10 @@ describe 'cassandra' do
     expect(service 'cassandra').to be_enabled
   end
 end
+
+describe 'jmx port' do
+  describe port(7199) do
+    it { should be_listening.on('127.0.0.1').with('tcp') }
+    it { should not_be_listening.on('0.0.0.0') }
+  end
+end

--- a/test/integration/tarball/serverspec/tarball_spec.rb
+++ b/test/integration/tarball/serverspec/tarball_spec.rb
@@ -13,3 +13,10 @@ describe 'cassandra' do
     expect(service 'cassandra').to be_enabled
   end
 end
+
+describe 'jmx port' do
+  describe port(7199) do
+    it { should be_listening.on('127.0.0.1').with('tcp') }
+    it { should not_be_listening.on('0.0.0.0') }
+  end
+end


### PR DESCRIPTION
Son of #256

This addresses CVE-20015-0225 which was fixed in cassandra
already but our cassandra-env.sh essentially reverted
the fix.

I could not really run the serverspec tests since
cassandra did not seem to start in vagrant and I
already wasted way too much time getting the chefspec
toolchain to install - spent hours on nokogiri alone...
I just hope that it's alright.