### PR TITLE
Install cassandra package only in case of community edition

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -80,10 +80,10 @@ when 'debian'
       pin "version #{node['cassandra']['version']}"
       pin_priority '700'
     end
-  end
 
-  package 'cassandra' do
-    version node['cassandra']['version']
+    package 'cassandra' do
+      version node['cassandra']['version']
+    end
   end
 
   package node['cassandra']['package_name'] do


### PR DESCRIPTION
This package is only available in the community repository of datastax.