### PR TITLE
Use 'confold' options so chef can upgrade cassandra

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -82,6 +82,7 @@ when 'debian'
     end
 
     package 'cassandra' do
+      options '--force-yes -o Dpkg::Options::="--force-confold"'
       version node['cassandra']['version']
     end
   end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -270,8 +270,12 @@ describe 'cassandra-dse::default' do
       )
     end
 
-    it 'installs cassandra dsc21 2.2.1-1' do
-      expect(chef_run).to install_package('dsc22')
+    it 'installs cassandra 2.2.1' do
+      expect(chef_run).to install_package('cassandra').with(version: '2.2.1')
+    end
+
+    it 'installs cassandra dsc22 2.2.1-1' do
+      expect(chef_run).to install_package('dsc22').with(version: '2.2.1-1')
     end
   end
 end


### PR DESCRIPTION
Without this, an upgrade fails because of modifications to the Cassandra config files, this adds the same options we use on the dsc package.  Not sure why we need to explicitly install both packages here...
Add spec tests to check version of Cassandra package.