### PR TITLE
Fix JAMM 0.2.5 for Cassandra 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Oracle JVM 8 tuning parameters: [here](https://docs.oracle.com/javase/8/docs/tec
 ### JAMM Attributes
 
  * `node[:cassandra][:setup_jamm]` (default: false): install the jamm jar file and use it to set java option `-javaagent`, obsolete for C* versions `>v0.8.0`
- * `node[:cassandra][:jamm][:sha256sum]` (default: e3dd1200c691f8950f51a50424dd133fb834ab2ce9920b05aa98024550601cc5): jamm lib sha256sum for version `0.2.5`
+ * `node[:cassandra][:jamm][:sha256sum]` (default: calculated): jamm lib sha256sum for calculated version
  * `node[:cassandra][:jamm][:base_url]` (default: calculated): jamm lib jar url
  * `node[:cassandra][:jamm][:jar_name]` (default: calculated): jamm lib jar name
  * `node[:cassandra][:jamm][:version]` (default: calculated): jamm lib version

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,7 +90,7 @@ default['cassandra']['metrics_reporter']['config'] = {} # should be a hash of re
 default['cassandra']['jamm']['version'] = jamm_version(node['cassandra']['version'])
 default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/jbellis/jamm/#{node['cassandra']['jamm']['version']}"
 default['cassandra']['jamm']['jar_name'] = "jamm-#{node['cassandra']['jamm']['version']}.jar"
-default['cassandra']['jamm']['sha256sum'] = 'b599dc7a58b305d697bbb3d897c91f342bbddefeaaf10a3fa156c93efca397ef'
+default['cassandra']['jamm']['sha256sum'] = jamm_sha256sum(node['cassandra']['jamm']['version'])
 
 # log configuration files
 default['cassandra']['log_config_files'] = node['cassandra']['version'] =~ /^[0-1]|^2.0/ ? %w(log4j-server.properties) : %w(logback.xml logback-tools.xml)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -88,7 +88,7 @@ default['cassandra']['metrics_reporter']['jar_name'] = 'metrics-graphite-2.2.0.j
 default['cassandra']['metrics_reporter']['config'] = {} # should be a hash of relevant config
 
 default['cassandra']['jamm']['version'] = jamm_version(node['cassandra']['version'])
-default['cassandra']['jamm']['base_url'] = "http://repo1.maven.org/maven2/com/github/jbellis/jamm/#{node['cassandra']['jamm']['version']}"
+default['cassandra']['jamm']['base_url'] = jamm_url(node['cassandra']['jamm']['version'])
 default['cassandra']['jamm']['jar_name'] = "jamm-#{node['cassandra']['jamm']['version']}.jar"
 default['cassandra']['jamm']['sha256sum'] = jamm_sha256sum(node['cassandra']['jamm']['version'])
 

--- a/libraries/config_helpers.rb
+++ b/libraries/config_helpers.rb
@@ -110,7 +110,7 @@ def jamm_sha256sum(version)
   when '0.2.2'
     'unknown'
   when '0.2.5'
-    'b599dc7a58b305d697bbb3d897c91f342bbddefeaaf10a3fa156c93efca397ef'
+    'e3dd1200c691f8950f51a50424dd133fb834ab2ce9920b05aa98024550601cc5'
   when '0.2.6'
     'c9577bba0321eeb5358fdea29634cbf124ae3742e80d729f3bd98e0e23726dbf'
   when '0.2.8'

--- a/libraries/config_helpers.rb
+++ b/libraries/config_helpers.rb
@@ -105,6 +105,16 @@ def jamm_version(version)
   end
 end
 
+def jamm_url(version)
+  owner = if version.to_s.strip == '0.2.5'
+            'stephenc'
+          else
+            'jbellis'
+          end
+
+  "http://repo1.maven.org/maven2/com/github/#{owner}/jamm/#{version}"
+end
+
 def jamm_sha256sum(version)
   case version.to_s.strip
   when '0.2.2'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -169,7 +169,7 @@ end
 # setup jamm
 remote_file "/usr/share/java/#{node['cassandra']['jamm']['jar_name']}" do
   source "#{node['cassandra']['jamm']['base_url']}/#{node['cassandra']['jamm']['jar_name']}"
-  checksum jamm_sha256sum(node['cassandra']['jamm']['version'])
+  checksum node['cassandra']['jamm']['sha256sum']
   only_if { node['cassandra']['setup_jamm'] }
 end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -192,8 +192,8 @@ describe 'cassandra-dse' do
 
     it 'downloads the /usr/share/java/jamm-0.2.5.jar jar' do
       expect(chef_run).to create_remote_file('/usr/share/java/jamm-0.2.5.jar').with(
-        source: 'http://repo1.maven.org/maven2/com/github/jbellis/jamm/0.2.5/jamm-0.2.5.jar',
-        checksum: 'b599dc7a58b305d697bbb3d897c91f342bbddefeaaf10a3fa156c93efca397ef'
+        source: 'http://repo1.maven.org/maven2/com/github/stephenc/jamm/0.2.5/jamm-0.2.5.jar',
+        checksum: 'e3dd1200c691f8950f51a50424dd133fb834ab2ce9920b05aa98024550601cc5'
       )
     end
 


### PR DESCRIPTION
JAMM install was failing for two reasons:
- The sha256 checksum was wrong
- The owner name for pre-0.2.6 JAMM is different (jbellis did not release 0.2.5)

I took the liberty to make the sha256sum configurable, the helper is used for the default attribute value instead of being called inside of the recipe :-)