### PR TITLE
Enable wrapper cookbooks to install Cassandra > 3.0.

### DIFF
--- a/attributes/datastax.rb
+++ b/attributes/datastax.rb
@@ -1,5 +1,6 @@
 
 default['cassandra']['package_name']  = 'dsc22'
+default['cassandra']['tools_package_name'] = 'python-cql'
 default['cassandra']['release']       = '1'
 
 default['cassandra']['yum']['repo'] = 'datastax'

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -67,7 +67,7 @@ when 'debian'
   unless node['cassandra']['dse']
     # DataStax Server Community Edition package will not install w/o this
     # one installed. MK.
-    package 'python-cql'
+    package node['cassandra']['tools_package_name']
 
     # This is necessary because apt gets very confused by the fact that the
     # latest package available for cassandra is 2.x while you're trying to

--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -73,7 +73,11 @@ when 'debian'
     # latest package available for cassandra is 2.x while you're trying to
     # install dsc12 which requests 1.2.x.
     apt_preference node['cassandra']['package_name'] do
-      pin "version #{node['cassandra']['version']}-#{node['cassandra']['release']}"
+      if node['cassandra']['release'].to_s != ""
+        pin "version #{node['cassandra']['version']}-#{node['cassandra']['release']}"
+      else
+        pin "version #{node['cassandra']['version']}"
+      end
       pin_priority '700'
     end
     apt_preference 'cassandra' do
@@ -90,7 +94,11 @@ when 'debian'
   package node['cassandra']['package_name'] do
     action :install
     options '--force-yes -o Dpkg::Options::="--force-confold"'
-    version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
+    if node['cassandra']['release'].to_s != ""
+      version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
+    else
+      version "#{node['cassandra']['version']}"
+    end
     # giving C* some time to start up
     notifies :start, 'service[cassandra]', :immediately
     notifies :run, 'ruby_block[sleep30s]', :immediately
@@ -127,7 +135,11 @@ when 'rhel'
   node.default['cassandra']['conf_dir'] = '/etc/cassandra/conf'
 
   yum_package node['cassandra']['package_name'] do
-    version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
+    if node['cassandra']['release'].to_s != ""
+      version "#{node['cassandra']['version']}-#{node['cassandra']['release']}"
+    else
+      version "#{node['cassandra']['version']}"
+    end
     allow_downgrade
     options node['cassandra']['yum']['options']
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -8,7 +8,7 @@ describe 'cassandra-dse' do
         node.set['cassandra']['config']['cluster_name'] = 'chefspec'
         node.set['cassandra']['metrics_reporter']['enabled'] = true
         node.set['cassandra']['rackdc'] = { 'dc' => 'testdc', 'rack' => 'testrack' }
-        node.set['cassandra']['snitch_conf'] = { 'dc' => 'testdc', 'rac' => 'testrack' }
+        node.set['cassandra']['snitch_conf'] = { 'dc' => 'testdc', 'rack' => 'testrack' }
         node.set['cassandra']['setup_jamm'] = true
         node.set['cassandra']['setup_priam'] = true
         node.set['cassandra']['setup_jna'] = true
@@ -97,7 +97,7 @@ describe 'cassandra-dse' do
         node.set['cassandra']['config']['cluster_name'] = 'chefspec'
         node.set['cassandra']['metrics_reporter']['enabled'] = true
         node.set['cassandra']['rackdc'] = { 'dc' => 'testdc', 'rack' => 'testrack' }
-        node.set['cassandra']['snitch_conf'] = { 'dc' => 'testdc', 'rac' => 'testrack' }
+        node.set['cassandra']['snitch_conf'] = { 'dc' => 'testdc', 'rack' => 'testrack' }
         node.set['cassandra']['setup_priam'] = true
         node.set['cassandra']['setup_jna'] = true
         node.set['cassandra']['notify_restart'] = true

--- a/templates/default/cassandra-topology.properties.erb
+++ b/templates/default/cassandra-topology.properties.erb
@@ -4,4 +4,4 @@
 #
 # Cassandra Node IP=Data Center:Rack
 
-default=<%= @snitch['dc'] %>:<%= @snitch['rac'] %>
+default=<%= @snitch['dc'] %>:<%= @snitch['rack'] %>


### PR DESCRIPTION
* Datastax has changed the tools package name from `python-cql` to `datastax-ddc-tools` for Cassandra > 3.0. This allows a wrapper cookbook to override the tools package name and install a newer Cassandra.
* Fixed typo in snitch config...`rac` should be `rack`.
* Do not append `"-{release}"` to version if cassandra.release is empty/nil.
    - Datastax has stopped appending `"-{release}"` tags in their version numbering.
    - This change only appends `"-{release}"` if cassandra.release is not empty/nil.