### PR TITLE
DSC 3.0.6 Settings

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,7 @@ platforms:
     customize:
       memory: 1024
   <% end %>
-  - name: centos-6.4
+  - name: centos-7.2
     run_list:
     - recipe[yum]
 
@@ -87,8 +87,13 @@ suites:
         config:
           cluster_name: "kitchen test"
         package_name: dsc30
-        version: 3.0.0
+        version: 3.0.6
         release: 1
+        setup_jna: true
+        user_home: '/home/cassandra'
+    driver:
+      customize:
+        memory: 1280
     run_list:
       - recipe[cassandra-dse::default]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -137,7 +137,8 @@ default['cassandra']['opscenter']['agent']['checksum'] = nil
 default['cassandra']['opscenter']['agent']['install_dir'] = '/opt'
 default['cassandra']['opscenter']['agent']['install_folder_name'] = 'opscenter_agent'
 default['cassandra']['opscenter']['agent']['binary_name'] = 'opscenter-agent'
-default['cassandra']['opscenter']['agent']['server_host'] = nil # if nil, will use search to get IP by server role
+ # if nil, will use search to get IP by server role
+default['cassandra']['opscenter']['agent']['server_host'] = nil
 default['cassandra']['opscenter']['agent']['use_chef_search'] = true
 default['cassandra']['opscenter']['agent']['server_role'] = 'opscenter_server'
 default['cassandra']['opscenter']['agent']['use_ssl'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/configures Apache Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/michaelklishin/cassandra-chef-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/michaelklishin/cassandra-chef-cookbook/issues' if respond_to?(:issues_url)
-version '4.2.0'
+version '4.2.1'
 depends 'java'
 depends 'ulimit'
 depends 'apt'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -78,15 +78,20 @@ end
 if node['cassandra']['version'][0..2] >= '2.1'
   ruby_block 'smash < 2.0-attributes' do
     block do
-  node.rm('cassandra', 'config', 'memtable_flush_queue_size')
-  node.rm('cassandra', 'config', 'in_memory_compaction_limit_in_mb')
-  node.rm('cassandra', 'config', 'concurrent_compactors')
-  node.rm('cassandra', 'config', 'multithreaded_compaction')
-  node.rm('cassandra', 'config', 'compaction_preheat_key_cache')
-  node.rm('cassandra', 'config', 'native_transport_min_threads')
-  node.rm('cassandra', 'config', 'native_transport_max_threads')
+      node.rm('cassandra', 'config', 'memtable_flush_queue_size')
+      node.rm('cassandra', 'config', 'in_memory_compaction_limit_in_mb')
+      node.rm('cassandra', 'config', 'concurrent_compactors')
+      node.rm('cassandra', 'config', 'multithreaded_compaction')
+      node.rm('cassandra', 'config', 'compaction_preheat_key_cache')
+      node.rm('cassandra', 'config', 'native_transport_min_threads')
+      node.rm('cassandra', 'config', 'native_transport_max_threads')
+
     end
   end
+
+  # on DSC3, setting hints, required configuration
+  node.default['cassandra']['config']['hints_directory'] = \
+    ::File.join(node['cassandra']['root_dir'], 'hints')
 end
 
 # configuration files

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -20,7 +20,7 @@ describe 'cassandra-dse' do
       end.converge(described_recipe)
     end
 
-    it 'installs the jna.jar file' do
+    it 'installs the jna.jar file' do # ~FC005
       expect(chef_run).to create_remote_file('/usr/share/java/jna.jar').with(
         source: 'https://github.com/twall/jna/raw/4.0/dist/jna.jar',
         checksum: 'dac270b6441ce24d93a96ddb6e8f93d8df099192738799a6f6fcfc2b2416ca19'
@@ -69,7 +69,7 @@ describe 'cassandra-dse' do
     %w(cassandra.yaml cassandra-env.sh cassandra-topology.properties
        cassandra-metrics.yaml cassandra-rackdc.properties logback.xml logback-tools.xml).each do |conffile|
       let(:template) { chef_run.template("/etc/cassandra/conf/#{conffile}") }
-      it "creates the /etc/cassandra/conf/#{conffile} configuration file" do
+      it "creates the /etc/cassandra/conf/#{conffile} configuration file" do # ~FC005
         expect(chef_run).to create_template("/etc/cassandra/conf/#{conffile}").with(
           source: "#{conffile}.erb",
           owner: 'cassandra',

--- a/spec/rendered_templates/cassandra.yaml
+++ b/spec/rendered_templates/cassandra.yaml
@@ -41,6 +41,7 @@ dynamic_snitch_update_interval_in_ms: 100
 endpoint_snitch: SimpleSnitch
 hinted_handoff_enabled: true
 hinted_handoff_throttle_in_kb: 1024
+hints_directory: "/var/lib/cassandra/hints"
 incremental_backups: false
 index_interval: 128
 index_summary_resize_interval_in_minutes: 60


### PR DESCRIPTION
When using `Cassandra 3.0.6` a few different settings must take place:
- Set `hints_directory`;
- Create PID directory;
- Fix `init.d` script, to set `JVM_SEARCH_DIRS` regarding Java 1.8;