### PR TITLE
Add attribute for cassandra tmp directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:installation_dir]` (default: `/usr/local/cassandra`): installation directory
  * `node[:cassandra][:root_dir]` (default: `/var/lib/cassandra`): data directory root
  * `node[:cassandra][:log_dir]` (default: `/var/log/cassandra`): log directory
- * `node[:cassandra][:tmp_dir]` (default: `/tmp`): tmp directory
+ * `node[:cassandra][:tmp_dir]` (default: none): tmp directory. Be careful what you set this to, as the cassandra user will be given ownership of that directory.
  * `node[:cassandra][:local_jmx]` (default: true): bind JMX listener to localhost
  * `node[:cassandra][:jmx_port]` (default: 7199): port to listen for JMX
  * `node[:cassandra][:notify_restart]` (default: false): notify Cassandra service restart upon resource update

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ documentation](http://www.datastax.com/documentation/cassandra/1.2/webhelp/cassa
  * `node[:cassandra][:installation_dir]` (default: `/usr/local/cassandra`): installation directory
  * `node[:cassandra][:root_dir]` (default: `/var/lib/cassandra`): data directory root
  * `node[:cassandra][:log_dir]` (default: `/var/log/cassandra`): log directory
+ * `node[:cassandra][:tmp_dir]` (default: `/tmp`): tmp directory
  * `node[:cassandra][:local_jmx]` (default: true): bind JMX listener to localhost
  * `node[:cassandra][:jmx_port]` (default: 7199): port to listen for JMX
  * `node[:cassandra][:notify_restart]` (default: false): notify Cassandra service restart upon resource update

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -49,6 +49,16 @@ directory '/usr/share/java' do
   mode '00755'
 end
 
+if node['cassandra']['tmp_dir']
+  directory "#{node['cassandra']['tmp_dir']}" do
+    action :create
+    recursive true
+    owner node['cassandra']['user']
+    group node['cassandra']['group']
+    mode '0755'
+  end
+end
+
 # delete properties on the basis of C* version
 # C* <= 2.0
 if node['cassandra']['version'][0..2] <= '2.0'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -49,14 +49,14 @@ directory '/usr/share/java' do
   mode '00755'
 end
 
-if node['cassandra']['tmp_dir']
-  directory "#{node['cassandra']['tmp_dir']}" do
-    action :create
-    recursive true
-    owner node['cassandra']['user']
-    group node['cassandra']['group']
-    mode '0755'
-  end
+
+directory "#{node['cassandra']['tmp_dir']}" do
+  action :create
+  recursive true
+  owner node['cassandra']['user']
+  group node['cassandra']['group']
+  mode '0755'
+  only_if { node['cassandra'].attribute?('tmp_dir') }
 end
 
 # delete properties on the basis of C* version

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -418,4 +418,8 @@ JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
 <% end %>
 # see https://issues.apache.org/jira/browse/CASSANDRA-6541
 JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
+<%if node['cassandra']['tmp_dir'] %>
+JVM_OPTS="$JVM_OPTS -Djna.tmpdir=<%= node['cassandra']['tmp_dir'] %>"
+JVM_OPTS="$JVM_OPTS -Djava.io.tmpdir=<%= node['cassandra']['tmp_dir'] %>"
+<% end %>
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"


### PR DESCRIPTION
I'm working on a custom RHEL image that as part of a set of security policies has the noexec flag set for the /tmp partition. Cassandra needs to execute some of its temporary files in order to boot successfully.

This pull request adds an attribute ```node['cassandra']['tmp_dir']```, and updates the config recipe to create this directory if it does not exist and if the attribute is set.

[More details from datastax.](http://docs.datastax.com/en/datastax_enterprise/4.8//datastax_enterprise/sec/secMakingTmpNonexecutable.html)