### PR TITLE
recipes: allow to set concurrent_compactors

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -90,7 +90,6 @@ if node['cassandra']['version'][0..2] >= '2.1'
     block do
       node.rm('cassandra', 'config', 'memtable_flush_queue_size')
       node.rm('cassandra', 'config', 'in_memory_compaction_limit_in_mb')
-      node.rm('cassandra', 'config', 'concurrent_compactors')
       node.rm('cassandra', 'config', 'multithreaded_compaction')
       node.rm('cassandra', 'config', 'compaction_preheat_key_cache')
       node.rm('cassandra', 'config', 'native_transport_min_threads')


### PR DESCRIPTION
one user could need to set an higher value for concurrent_compactors
e.g "data directories are backed by SSD" as stated in the documentation

I don't really this why this value is systematically removed