### PR TITLE
Add syslog appender to log to remote servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ Oracle JVM 8 tuning parameters: [here](https://docs.oracle.com/javase/8/docs/tec
  * `node[:cassandra][:logback][:file][:pattern]` (default: "%-5level [%thread] %date{ISO8601} %F:%L - %msg%n"): logback File appender log pattern
  * `node[:cassandra][:logback][:stdout][:enable]` (default: true): enable logback STDOUT appender
  * `node[:cassandra][:logback][:stdout][:pattern]` (default: "%-5level %date{HH:mm:ss,SSS} %msg%n"): logback STDOUT appender log pattern
+ * `node[:cassandra][:logback][:syslog][:enable]` (default: false): enable logback SYSLOG appender. Requires RSYSLOG be installed and running on the node.
+ * `node[:cassandra][:logback][:syslog][:host]` (default: localhost): The host name the syslog is written to.
+ * `node[:cassandra][:logback][:syslog][:facility]` (default: USER) The facility specified for the appender.
+ * `node[:cassandra][:logback][:syslog][:pattern]` (default: "%-5level [%thread] %F:%L - %msg%n") lockback SYSLOG appender log pattern
 
 
 ### Ulimit Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,11 @@ default['cassandra']['logback']['file']['pattern'] = '%-5level [%thread] %date{I
 default['cassandra']['logback']['stdout']['enable'] = true
 default['cassandra']['logback']['stdout']['pattern'] = '%-5level %date{HH:mm:ss,SSS} %msg%n'
 
+default['cassandra']['logback']['syslog']['enable'] = false
+default['cassandra']['logback']['syslog']['host'] = 'localhost'
+default['cassandra']['logback']['syslog']['facility'] = 'USER'
+default['cassandra']['logback']['syslog']['pattern'] = '%-5level [%thread] %F:%L - %msg%n'
+
 default['cassandra']['log4j'] = {}
 
 data_dir = []

--- a/spec/rendered_templates/logback.xml
+++ b/spec/rendered_templates/logback.xml
@@ -49,6 +49,7 @@
     </encoder>
   </appender>
 
+
   <root level="INFO">
     <appender-ref ref="FILE" />
     <appender-ref ref="STDOUT" />

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -51,10 +51,21 @@
   </appender>
   <% end -%>
 
+  <% if node.cassandra.logback.syslog.enable -%>
+  <appender name="RSYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
+    <syslogHost><%= node.cassandra.logback.syslog.host %></syslogHost>
+    <facility><%= node.cassandra.logback.syslog.facility %></facility>
+    <suffixPattern><%= node.cassandra.logback.syslog.pattern %></suffixPattern>
+  </appender>
+  <% end -%>
+
   <root level="INFO">
     <appender-ref ref="FILE" />
     <% if node.cassandra.logback.stdout.enable -%>
     <appender-ref ref="STDOUT" />
+    <% end -%>
+    <% if node.cassandra.logback.syslog.enable -%>
+    <appender-ref ref="RSYSLOG" />
     <% end -%>
   </root>
 


### PR DESCRIPTION
This is to enable syslog appender in logback to log to a remote server such as splunk.

As I am writing this I am wondering if rsyslog cookbook should be included as well instead of just documenting the dependency. Let me know what you think.

Thanks.