### PR TITLE
define jamm version for cassandra 3.[0-9]

### DIFF
--- a/libraries/config_helpers.rb
+++ b/libraries/config_helpers.rb
@@ -100,11 +100,7 @@ def jamm_version(version)
     '0.3.0'
   when /^2.2/
     '0.3.1'
-  when /^3.0/
-    '0.3.1'
-  when /^3.5/
-    '0.3.1'
-  when /^3.7/
+  when /^3.[0-9]/
     '0.3.1'
   end
 end


### PR DESCRIPTION
so we now support all available versions