### PR TITLE
Systemd service: Avoid 'systemctl start cassandra' to hang forever

### DIFF
--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -9,7 +9,7 @@ systemd_service 'cassandra' do
     wanted_by 'multi-user.target'
   end
   service do
-    type 'oneshot'
+    type 'forking'
     standard_output 'journal'
     standard_error 'inherit'
     environment 'CASSANDRA_HOME' => node.cassandra.installation_dir, \


### PR DESCRIPTION
Systemd will lose track of cassandra when you use the 'oneshot' type in service file.
And if you do systemctl start cassandra in a tty, it will hang forever, as systemd is waiting for cassandra to stop.

Using the forking type fix this behavior

https://www.freedesktop.org/software/systemd/man/systemd.service.html
