### PR TITLE
Systemd service: improvements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+default['systemd']['units_dir'] = '/etc/systemd/system'
+
 default['java']['jdk_version'] = '7'
 default['java']['install_flavor'] = 'oracle'
 default['java']['set_default'] = true

--- a/templates/default/cassandra.service.erb
+++ b/templates/default/cassandra.service.erb
@@ -1,0 +1,23 @@
+[Unit]
+Description=cassandra daemon
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=<%= node.cassandra.installation_dir %>/bin/cassandra -f -p <%= node.cassandra.pid_dir %>/cassandra.pid
+Type=simple
+User=<%= node.cassandra.user %>
+Group=<%= node.cassandra.group %>
+StandardOutput=journal
+StandardError=inherit
+Environment="CASSANDRA_HOME=<%= node.cassandra.installation_dir %>" "CASSANDRA_CONF=<%= node.cassandra.conf_dir %>"
+LimitNOFILE=infinity
+TimeoutStopSec=10min
+PIDFile=<%= node.cassandra.pid_dir %>/cassandra.pid
+ExecStop=<%= node.cassandra.installation_dir %>/bin/nodetool  disablegossip
+ExecStop=<%= node.cassandra.installation_dir %>/bin/nodetool  disablethrift
+ExecStop=<%= node.cassandra.installation_dir %>/bin/nodetool  drain
+ExecStop=-<%= node.cassandra.installation_dir %>/bin/nodetool stopdaemon


### PR DESCRIPTION
Various improvements over the original config

+ Switch from chef-systemd to a template to allow multiple ExecStop
+ Start cassandra in foreground to be able to have output in journalctl
+ Add timeoutStopExec to avoid that systemd kill "nodetool drain" too early
+ remove -h argument in nodetool, as cassandra utility can be only listenning on loopback
+ Use nodetool stopdaemon instead of kill $PID
+ Suppress exit code of nodetool stopdaemon, so the service appears clean when stopped
