### PR TITLE
Fixing bin path when installing from repos

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -33,7 +33,7 @@ end
 
 node.default['cassandra']['installation_dir'] = '/usr/share/cassandra'
 # node['cassandra']['installation_dir subdirs
-node.default['cassandra']['bin_dir']   = ::File.join(node['cassandra']['installation_dir'], 'bin')
+node.default['cassandra']['bin_dir'] = '/usr/bin' # package default folder for tools
 node.default['cassandra']['lib_dir'] = ::File.join(node['cassandra']['installation_dir'], 'lib')
 
 # commit log, data directory, saved caches and so on are all stored under the data root. MK.
@@ -183,7 +183,6 @@ end
 directories = [
   node['cassandra']['installation_dir'],
   node['cassandra']['conf_dir'],
-  node['cassandra']['bin_dir'],
   node['cassandra']['log_dir'],
   node['cassandra']['root_dir'],
   node['cassandra']['lib_dir'],

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -31,7 +31,7 @@ describe 'cassandra-dse::default' do
       end
 
       it 'creates the cassandra home directory' do
-        %w(/usr/share/cassandra /usr/share/cassandra/bin /var/log/cassandra /var/lib/cassandra /usr/share/cassandra/lib).each do |d|
+        %w(/usr/share/cassandra /var/log/cassandra /var/lib/cassandra /usr/share/cassandra/lib).each do |d|
           expect(chef_run).to create_directory(d).with(
             owner: 'cassandra',
             group: 'cassandra'


### PR DESCRIPTION
Hi !

Currently when we're using `datastax` recipe (install from repos), `node['cassandra']['bin_dir']` is pointing to `/usr/share/cassandra/bin`.

But when using package setup, this directory is empty :crying_cat_face: .
This patch should fix `bin_dir` (and add `sbin` dir) and make it point to `/usr/(s)bin` so we'll finally have an attribute to get thoses dir.