### PR TITLE
Custom sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,18 @@ Oracle JVM 8 tuning parameters: [here](https://docs.oracle.com/javase/8/docs/tec
  * `node[:cassandra][:opscenter][:cassandra_metrics][:1min_ttl]` (default: 604800)
  * `node[:cassandra][:opscenter][:cassandra_metrics][:5min_ttl]` (default: 2419200)
  * `node[:cassandra][:opscenter][:cassandra_metrics][:2hr_ttl]` (default: 31536000)
+ * `node[:cassandra][:opscenter][:custom_configuration]` (default: {}) A hash of custom configuration to set on [opscenterd.conf](https://docs.datastax.com/en/opscenter/6.0/opsc/configure/opscConfigProps_r.html), eg:
+
+ ```
+{
+  'ui' => {
+    'default_api_timeout' => 300
+  },
+  'stat_reporter' => {
+    'interval' => 1
+  }
+}
+ ```
 
 #### DataStax Ops Center Agent Tarball attributes
  * `node[:cassandra][:opscenter][:agent][:download_url]` (default: "") Required. You need to specify

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -150,6 +150,8 @@ default['cassandra']['opscenter']['cassandra_metrics']['1min_ttl'] = 604800
 default['cassandra']['opscenter']['cassandra_metrics']['5min_ttl'] = 2419200
 default['cassandra']['opscenter']['cassandra_metrics']['2hr_ttl'] = 31536000
 
+default['cassandra']['opscenter']['custom_configuration'] = {}
+
 default['cassandra']['opscenter']['agent']['package_name'] = 'datastax-agent'
 default['cassandra']['opscenter']['agent']['download_url'] = nil
 default['cassandra']['opscenter']['agent']['checksum'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -144,7 +144,7 @@ default['cassandra']['opscenter']['server']['port'] = '8888'
 default['cassandra']['opscenter']['server']['interface'] = '0.0.0.0'
 default['cassandra']['opscenter']['server']['authentication'] = false
 
-default['cassandra']['opscenter']['cassandra_metrics']['ignored_keyspaces'] = %w(system, OpsCenter)
+default['cassandra']['opscenter']['cassandra_metrics']['ignored_keyspaces'] = %w(system OpsCenter)
 default['cassandra']['opscenter']['cassandra_metrics']['ignored_column_families'] = []
 default['cassandra']['opscenter']['cassandra_metrics']['1min_ttl'] = 604800
 default['cassandra']['opscenter']['cassandra_metrics']['5min_ttl'] = 2419200

--- a/templates/default/opscenterd.conf.erb
+++ b/templates/default/opscenterd.conf.erb
@@ -60,3 +60,13 @@ ignored_column_families = <%= node['cassandra']['opscenter']['cassandra_metrics'
 # Expire 2 hour data points after 365 days
 2hr_ttl = <%= node['cassandra']['opscenter']['cassandra_metrics']['2hr_ttl'] %>
 
+<% node['cassandra']['opscenter']['custom_configuration'].each do |section, config| %>
+    <% if %w(http_proxy_settings security definitions ldap stat_reporter hadoop spark cloud repair_service ui request_tracker clusters failover lifecycle_manager agents).include? section %>
+[<%= section %>]
+        <% config.each do |key,value| %>
+<%= key %> = <%= value %>
+        <% end %>
+
+    <% end %>
+<% end %>
+


### PR DESCRIPTION
Add the option to pass custom configuration to `opscenterd.conf`. In my use case it's in order to set:

```
[ui]
default_api_timeout = 300
```

which is 10 seconds by default and not enough for me. To set:

```
node.default['cassandra']['opscenter']['custom_configuration'] = {
  'ui' => {
    'default_api_timeout' => 300
  }
}
```

Also fix my previous PR by removing a comma.