### PR TITLE
config: do not remove native_transport_max_threads

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -92,7 +92,6 @@ if node['cassandra']['version'][0..2] >= '2.1'
       node.rm('cassandra', 'config', 'multithreaded_compaction')
       node.rm('cassandra', 'config', 'compaction_preheat_key_cache')
       node.rm('cassandra', 'config', 'native_transport_min_threads')
-      node.rm('cassandra', 'config', 'native_transport_max_threads')
     end
   end
 end


### PR DESCRIPTION
it still exists in 2.1.x:
https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html#reference_ds_qfg_n1r_1k__native_transport_max_threads
in 3.x as well:
https://docs.datastax.com/en/cassandra/3.x/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__native_transport_max_threads