### PR TITLE
Remove check of existence for source_dir and installation_dir

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -79,19 +79,6 @@ end
   end
 end
 
-# Ensure that node['cassandra']['source_dir'] node['cassandra']['installation_dir'] directories both exist
-[
-  node['cassandra']['source_dir'],
-  node['cassandra']['installation_dir']
-].each do |dir|
-  directory dir do
-    owner node['cassandra']['user']
-    group node['cassandra']['group']
-    recursive true
-    mode 0755
-  end
-end
-
 # extract archive to node['cassandra']['source_dir'] and update one time ownership permissions
 bash 'extract_cassandra_source' do
   user 'root'


### PR DESCRIPTION
No need to check the existence of source_dir before installation because this directory  will be created during installation by extraction of tarball (as user root)
No need either to check existence of installation_dir because it will be created as a symbolic link of source_dir