### PR TITLE
Support disabling both systemd and initd when installing from tarball.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ default['cassandra']['user_home'] = nil
 default['cassandra']['system_user'] = true
 default['cassandra']['version'] = '2.2.0'
 default['cassandra']['use_systemd'] = false
+default['cassandra']['use_initd'] = true
 
 # jamm library was added in v0.8.0 and
 # not required for later versions

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -274,8 +274,18 @@ template node['cassandra']['jmx_password_path'] do
   only_if { node['cassandra']['jmx_remote_authenticate'] }
 end
 
+resource_exists = proc do |name|
+  begin
+    resources name
+    true
+  rescue Chef::Exceptions::ResourceNotFound
+    false
+  end
+end
+
 service 'cassandra' do
   supports restart: true, status: true
   service_name node['cassandra']['service_name']
   action node['cassandra']['service_action']
+  only_if { resource_exists['ruby_block[cassandra]'] }
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -274,18 +274,9 @@ template node['cassandra']['jmx_password_path'] do
   only_if { node['cassandra']['jmx_remote_authenticate'] }
 end
 
-resource_exists = proc do |name|
-  begin
-    resources name
-    true
-  rescue Chef::Exceptions::ResourceNotFound
-    false
-  end
-end
-
 service 'cassandra' do
   supports restart: true, status: true
   service_name node['cassandra']['service_name']
   action node['cassandra']['service_action']
-  only_if { resource_exists['ruby_block[cassandra]'] }
+  only_if { node['cassandra']['use_initd'] || node['cassandra']['use_systemd'] }
 end

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -177,7 +177,7 @@ ruby_block 'require_pam_limits.so' do
   only_if { ::File.readlines('/etc/pam.d/su').grep(/# #{pam_limits}/).any? }
 end
 
-if node['cassandra']['use_systemd'] == false
+if node['cassandra']['use_initd'] == true
   # sysv service file
   template "/etc/init.d/#{node['cassandra']['service_name']}" do
     source "#{node['platform_family']}.cassandra.init.erb"
@@ -186,7 +186,7 @@ if node['cassandra']['use_systemd'] == false
     mode '0755'
     notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
   end
-else
+elseif node['cassandra']['use_systemd'] == true
   node.default['cassandra']['startup_program'] = ::File.join(node['cassandra']['bin_dir'], 'cassandra')
   include_recipe 'cassandra-dse::systemd'
 end

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -177,7 +177,7 @@ ruby_block 'require_pam_limits.so' do
   only_if { ::File.readlines('/etc/pam.d/su').grep(/# #{pam_limits}/).any? }
 end
 
-if node['cassandra']['use_initd'] == true
+if node['cassandra']['use_initd']
   # sysv service file
   template "/etc/init.d/#{node['cassandra']['service_name']}" do
     source "#{node['platform_family']}.cassandra.init.erb"
@@ -186,7 +186,7 @@ if node['cassandra']['use_initd'] == true
     mode '0755'
     notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
   end
-elsif node['cassandra']['use_systemd'] == true
+elsif node['cassandra']['use_systemd']
   node.default['cassandra']['startup_program'] = ::File.join(node['cassandra']['bin_dir'], 'cassandra')
   include_recipe 'cassandra-dse::systemd'
 end

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -186,7 +186,7 @@ if node['cassandra']['use_initd'] == true
     mode '0755'
     notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
   end
-elseif node['cassandra']['use_systemd'] == true
+elsif node['cassandra']['use_systemd'] == true
   node.default['cassandra']['startup_program'] = ::File.join(node['cassandra']['bin_dir'], 'cassandra')
   include_recipe 'cassandra-dse::systemd'
 end


### PR DESCRIPTION
This is required for omnibus installations. by default omnibus uses runit as service management.