### PR TITLE
make it possible to specify -D options at the jvm startup

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,6 +138,8 @@ default['cassandra']['jvm']['resize_tlab'] = true
 default['cassandra']['jvm']['agentpath'] = nil
 default['cassandra']['jvm']['misc_java_agents'] = []
 
+default['cassandra']['jvm']['misc_jvm_options'] = []
+
 default['cassandra']['gc_survivor_ratio'] = 8
 default['cassandra']['gc_max_tenuring_threshold'] = 1
 default['cassandra']['gc_cms_initiating_occupancy_fraction'] = 75

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -335,6 +335,12 @@ JVM_OPTS="$JVM_OPTS -javaagent:<%= agent.to_s -%>"
 <% end %>
 <% end %>
 
+<% if node['cassandra']['jvm']['misc_jvm_options'] %>
+<% node['cassandra']['jvm']['misc_jvm_options'].each do |option| %>
+JVM_OPTS="$JVM_OPTS -D<%= option.to_s -%>"
+<% end %>
+<% end %>
+
 JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
 JVM_OPTS="$JVM_OPTS $MX4J_PORT"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -50,7 +50,6 @@
     </encoder>
   </appender>
 
-  <% if node['cassandra']['logback']['debug']['enable'] -%>
   <!-- DEBUGLOG rolling file appender to debug.log (all levels) -->
 
   <appender name="DEBUGLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -76,7 +75,6 @@
     <includeCallerData>true</includeCallerData>
     <appender-ref ref="DEBUGLOG" />
   </appender>
-  <% end -%>
 
   <% if node['cassandra']['logback']['stdout']['enable'] -%>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
Hello,

This PR aims to make it possible for the user to specify custom options to pass to cassandra at the jvm startup.

This feature is useful when you want to toggle expiremental features of cassandra