### PR TITLE
Fixes for systemd, style and spec tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,12 @@
-#!/usr/bin/env rake
-
 require 'foodcritic'
 require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
 
 desc 'Run all lints'
-task lint: %w(foodcritic rubocop)
-task unit: %w(foodcritic rubocop spec)
-task default: %w(foodcritic rubocop spec integration:vagrant)
-task docker: %w(foodcritic rubocop spec integration:docker)
+task lint: %w[foodcritic rubocop]
+task unit: %w[foodcritic rubocop spec]
+task default: %w[foodcritic rubocop spec integration:vagrant]
+task docker: %w[foodcritic rubocop spec integration:docker]
 
 desc 'Run Rubocop Lint Task'
 task :rubocop do

--- a/attributes/datastax.rb
+++ b/attributes/datastax.rb
@@ -17,6 +17,6 @@ default['cassandra']['apt']['repo'] = 'datastax'
 default['cassandra']['apt']['uri'] = 'https://debian.datastax.com/community/' # for dsc (not dse)
 default['cassandra']['apt']['dse_uri'] = 'debian.datastax.com/enterprise' # for dse
 default['cassandra']['apt']['distribution'] = 'stable'
-default['cassandra']['apt']['components'] = %w(main)
+default['cassandra']['apt']['components'] = %w[main]
 default['cassandra']['apt']['repo_key'] = 'https://debian.datastax.com/debian/repo_key'
 default['cassandra']['apt']['action'] = :add

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['cassandra']['priam']['sha256sum'] = '9fde9a40dc5c538adee54f40fa9027cf3e
 
 default['cassandra']['pid_dir'] = '/var/run/cassandra'
 default['cassandra']['dir_mode'] = '0755'
-default['cassandra']['service_action'] = [:enable, :start]
+default['cassandra']['service_action'] = %i[enable start]
 default['cassandra']['jmx_port'] = 7199
 default['cassandra']['local_jmx'] = true
 default['cassandra']['jmx_remote_rmi_port'] = '$JMX_PORT'
@@ -113,7 +113,7 @@ default['cassandra']['jamm']['jar_name'] = "jamm-#{node['cassandra']['jamm']['ve
 default['cassandra']['jamm']['sha256sum'] = jamm_sha256sum(node['cassandra']['jamm']['version'])
 
 # log configuration files
-default['cassandra']['log_config_files'] = node['cassandra']['version'] =~ /^[0-1]|^2.0/ ? %w(log4j-server.properties) : %w(logback.xml logback-tools.xml)
+default['cassandra']['log_config_files'] = node['cassandra']['version'] =~ /^[0-1]|^2.0/ ? %w[log4j-server.properties] : %w[logback.xml logback-tools.xml]
 
 # Heap Dump
 default['cassandra']['heap_dump'] = true
@@ -154,7 +154,7 @@ default['cassandra']['opscenter']['server']['port'] = '8888'
 default['cassandra']['opscenter']['server']['interface'] = '0.0.0.0'
 default['cassandra']['opscenter']['server']['authentication'] = false
 
-default['cassandra']['opscenter']['cassandra_metrics']['ignored_keyspaces'] = %w(system OpsCenter)
+default['cassandra']['opscenter']['cassandra_metrics']['ignored_keyspaces'] = %w[system OpsCenter]
 default['cassandra']['opscenter']['cassandra_metrics']['ignored_column_families'] = []
 default['cassandra']['opscenter']['cassandra_metrics']['1min_ttl'] = 604800
 default['cassandra']['opscenter']['cassandra_metrics']['5min_ttl'] = 2419200

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,6 @@ depends 'systemd'
 
 chef_version '>= 12'
 
-%w(ubuntu centos redhat fedora amazon).each do |os|
+%w[ubuntu centos redhat fedora amazon].each do |os|
   supports os
 end

--- a/recipes/opscenter_agent_datastax.rb
+++ b/recipes/opscenter_agent_datastax.rb
@@ -46,7 +46,7 @@ end
 
 service 'datastax-agent' do
   supports restart: true, status: true
-  action [:enable, :start]
+  action %i[enable start]
   subscribes :restart, "package[#{ops_agent['package_name']}]"
 end
 

--- a/recipes/opscenter_server.rb
+++ b/recipes/opscenter_server.rb
@@ -30,7 +30,7 @@ end
 
 service 'opscenterd' do
   supports restart: true, status: true
-  action [:enable, :start]
+  action %i[enable start]
   subscribes :restart, "package[#{ops_server['package_name']}]"
 end
 

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -12,6 +12,6 @@ template ::File.join(node['systemd']['units_dir'], node['cassandra']['service_na
   group node['cassandra']['group']
   mode '0644'
   notifies :run, 'execute[daemon-reload]', :immediately
-  notifies :enable, 'service[cassandra]', :immediately
+  notifies :enable, 'service[cassandra]', :delayed
   notifies :restart, 'service[cassandra]', :delayed if node['cassandra']['notify_restart']
 end

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -142,7 +142,7 @@ template ::File.join(node['cassandra']['installation_dir'], 'bin', 'cqlsh') do
   not_if { ::File.exist?(::File.join(node['cassandra']['installation_dir'], 'bin', 'cqlsh')) }
 end
 
-%w(cqlsh cassandra cassandra-shell cassandra-cli nodetool).each do |f|
+%w[cqlsh cassandra cassandra-shell cassandra-cli nodetool].each do |f|
   link "/usr/local/bin/#{f}" do
     owner node['cassandra']['user']
     group node['cassandra']['group']
@@ -200,7 +200,7 @@ end
 ruby_block 'purge-old-tarball' do
   block do
     require 'fileutils'
-    installed_versions = Dir.entries('/usr/local').reject { |a| a !~ /^apache-cassandra/ }.sort
+    installed_versions = Dir.entries('/usr/local').select { |a| a =~ /^apache-cassandra/ }.sort
     old_versions = installed_versions - ["apache-cassandra-#{node['cassandra']['version']}"]
 
     old_versions.each do |v|

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -20,7 +20,7 @@ describe 'cassandra-dse::config' do
         node.override['cassandra']['jvm']['g1'] = true
 
         # provide a testable hash to verify template generation
-        node.override['cassandra']['metrics_reporter']['config'] = { 'test1' => 'value1', 'test2' => %w(value2 value3) }
+        node.override['cassandra']['metrics_reporter']['config'] = { 'test1' => 'value1', 'test2' => %w[value2 value3] }
       end.converge(described_recipe)
     end
 
@@ -76,8 +76,8 @@ describe 'cassandra-dse::config' do
       )
     end
 
-    %w(cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
-       cassandra-metrics.yaml cassandra-rackdc.properties logback.xml logback-tools.xml).each do |conffile|
+    %w[cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
+       cassandra-metrics.yaml cassandra-rackdc.properties logback.xml logback-tools.xml].each do |conffile|
       let(:template) { chef_run.template("/etc/cassandra/conf/#{conffile}") }
       it "creates the /etc/cassandra/conf/#{conffile} configuration file" do # ~FC005
         expect(chef_run).to create_template("/etc/cassandra/conf/#{conffile}").with(
@@ -118,12 +118,12 @@ describe 'cassandra-dse::config' do
         node.override['cassandra']['jvm']['g1'] = true
 
         # provide a testable hash to verify template generation
-        node.override['cassandra']['metrics_reporter']['config'] = { 'test1' => 'value1', 'test2' => %w(value2 value3) }
+        node.override['cassandra']['metrics_reporter']['config'] = { 'test1' => 'value1', 'test2' => %w[value2 value3] }
       end.converge(described_recipe)
     end
 
-    %w(cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
-       cassandra-metrics.yaml cassandra-rackdc.properties logback.xml logback-tools.xml).each do |conffile|
+    %w[cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
+       cassandra-metrics.yaml cassandra-rackdc.properties logback.xml logback-tools.xml].each do |conffile|
       let(:template) { chef_run.template("/etc/cassandra/#{conffile}") }
 
       it "creates the /etc/cassandra/#{conffile} configuration file" do
@@ -402,8 +402,8 @@ describe 'cassandra-dse::config' do
       expect(chef_run).to run_ruby_block('smash >= 2.1-attributes')
     end
 
-    %w(cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
-       cassandra-metrics.yaml cassandra-rackdc.properties log4j-server.properties).each do |conffile|
+    %w[cassandra.yaml cassandra-env.sh cassandra-topology.properties jvm.options
+       cassandra-metrics.yaml cassandra-rackdc.properties log4j-server.properties].each do |conffile|
       let(:template) { chef_run.template("/etc/cassandra/conf/#{conffile}") }
       it "creates the /etc/cassandra/conf/#{conffile} configuration file" do # ~FC005
         expect(chef_run).to create_template("/etc/cassandra/conf/#{conffile}").with(

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -31,14 +31,14 @@ describe 'cassandra-dse::default' do
       end
 
       it 'creates the cassandra home directory' do
-        %w(
+        %w[
           /var/log/cassandra
           /var/lib/cassandra
           /var/lib/cassandra/data
           /var/run/cassandra
           /usr/share/cassandra
           /usr/share/cassandra/lib
-        ).each do |d|
+        ].each do |d|
           expect(chef_run).to create_directory(d).with(
             owner: 'cassandra',
             group: 'cassandra'
@@ -275,13 +275,13 @@ describe 'cassandra-dse::default' do
       expect(link).to link_to('/etc/cassandra/conf')
     end
 
-    %w(
+    %w[
       cassandra.yaml
       cassandra-env.sh
       jvm.options
       logback.xml
       logback-tools.xml
-    ).each do |conffile|
+    ].each do |conffile|
       it "creates the /etc/mycassandra/conf/#{conffile} configuration file" do
         expect(chef_run).to create_template("/etc/mycassandra/conf/#{conffile}").with(
           source: "#{conffile}.erb",
@@ -292,13 +292,13 @@ describe 'cassandra-dse::default' do
       end
     end
 
-    %w(
+    %w[
       cassandra-topology.properties
       cassandra-metrics.yaml
       cassandra-rackdc.properties
       jmxremote.access
       jmxremote.password
-    ).each do |conffile|
+    ].each do |conffile|
       it "does not create the /etc/mycassandra/conf/#{conffile} configuration file" do
         expect(chef_run).to_not create_template("/etc/mycassandra/conf/#{conffile}")
       end

--- a/spec/opscenter_agent_datastax_spec.rb
+++ b/spec/opscenter_agent_datastax_spec.rb
@@ -15,7 +15,7 @@ describe 'cassandra-dse::opscenter_agent_datastax' do
   end
 
   it 'installs the agent package' do
-    expect(chef_run).to install_package('datastax-agent').with(options: '--always-have-options')
+    expect(chef_run).to install_package('datastax-agent').with(options: ['--always-have-options'])
   end
 
   it 'starts & enables the service' do

--- a/spec/rendered_templates/cassandra-env.sh
+++ b/spec/rendered_templates/cassandra-env.sh
@@ -298,6 +298,8 @@ JVM_OPTS="$JVM_OPTS -Dcassandra.metricsReporterConfigFile=cassandra-metrics.yaml
 JVM_OPTS="$JVM_OPTS -XX:+CMSClassUnloadingEnabled"
 
 
+
+
 JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
 JVM_OPTS="$JVM_OPTS $MX4J_PORT"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"

--- a/spec/repositories_spec.rb
+++ b/spec/repositories_spec.rb
@@ -33,7 +33,7 @@ describe 'cassandra-dse::repositories' do
       expect(chef_run).to add_apt_repository('datastax').with(
         uri: 'https://debian.datastax.com/community/',
         distribution: 'stable',
-        components: %w(main),
+        components: %w[main],
         key: 'https://debian.datastax.com/debian/repo_key'
       )
     end

--- a/spec/seed_selection_spec.rb
+++ b/spec/seed_selection_spec.rb
@@ -5,7 +5,7 @@ describe 'cassandra-dse' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
         node.override['cassandra']['config']['cluster_name'] = 'chefspec'
-        node.override['cassandra']['seeds'] = %w(seed1 seed2)
+        node.override['cassandra']['seeds'] = %w[seed1 seed2]
       end.converge(described_recipe)
     end
 

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'cassandra-dse::systemd' do
+  context 'Centos 7.0' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0') do |node|
+        node.override['cassandra']['config']['cluster_name'] = 'test'
+        node.override['cassandra']['conf_dir'] = '/etc/cassandra/conf'
+        node.override['cassandra']['use_systemd'] = true
+        node.override['cassandra']['notify_restart'] = true
+        node.set['systemd']['units_dir'] = '/etc/systemd/system'
+      end.converge('cassandra-dse::config', described_recipe)
+    end
+
+    it 'declares the daemon-reload resource' do
+      resource = chef_run.execute('daemon-reload')
+      expect(resource).to do_nothing
+    end
+
+    it 'creates the systemd unit file' do
+      expect(chef_run).to create_template('/etc/systemd/system/cassandra.service').with(
+        source: 'cassandra.service.erb',
+        owner: 'cassandra',
+        group: 'cassandra',
+        mode: '0644'
+      )
+      template = chef_run.template('/etc/systemd/system/cassandra.service')
+      expect(template).to notify('execute[daemon-reload]').to(:run).immediately
+      expect(template).to notify('service[cassandra]').to(:enable).delayed
+      expect(template).to notify('service[cassandra]').to(:restart).delayed
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a notification in the systemd recipe. It has three commits, being the first one the relevant one. The other commits just fix the style and some minor failures in the spec tests.

* First commit fixes the `systemd` recipe to send a delayed notification for the C* service enable. There is no need to enable it `:immediately`. Doing that affects resources that are subscribed to the `service[cassandra]` status, as enabling it immediately would trigger a status change and enqueue eagerly their subscriptions, which might have expected notifications to be delayed, as defined in the `:restart` action. Notifications should be better triggered the same way regardless of the action, to have consistent a behavior on subscribers.
* Second commit fixes the style to make Rubocop happy.
* The third commit fixes a couple minor spec test failures.
