### PR TITLE
Add the possibility to override specific logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Oracle JVM 8 tuning parameters: [here](https://docs.oracle.com/javase/8/docs/tec
  * `node[:cassandra][:logback][:syslog][:host]` (default: localhost): The host name the syslog is written to.
  * `node[:cassandra][:logback][:syslog][:facility]` (default: USER) The facility specified for the appender.
  * `node[:cassandra][:logback][:syslog][:pattern]` (default: "%-5level [%thread] %F:%L - %msg%n") lockback SYSLOG appender log pattern
+ * `node[:cassandra][:logback][:override_loggers]` (default: {}) Override log level of specific logger (i.e { 'org.apache.cassandra.utils.StatusLogger' => 'WARN' })
 
 
 ### Ulimit Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,6 +80,8 @@ default['cassandra']['logback']['syslog']['host'] = 'localhost'
 default['cassandra']['logback']['syslog']['facility'] = 'USER'
 default['cassandra']['logback']['syslog']['pattern'] = '%-5level [%thread] %F:%L - %msg%n'
 
+default['cassandra']['logback']['override_loggers'] = {}
+
 default['cassandra']['log4j'] = {}
 
 data_dir = []

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -114,4 +114,7 @@
 
   <logger name="org.apache.cassandra" level="INFO"/>
   <logger name="com.thinkaurelius.thrift" level="ERROR"/>
+  <% node['cassandra']['logback']['override_loggers'].each do |logger, level| %>
+  <logger name="<%= logger %>" level="<%= level %>"/>
+  <% end %>
 </configuration>


### PR DESCRIPTION
This feature is useful when you want to debug a specific codepath of cassandra, or when you want to disable verbose logging (StatusLogger) because you already have monitoring in place