### PR TITLE
Add missing directories to datastax recipe

### DIFF
--- a/recipes/datastax.rb
+++ b/recipes/datastax.rb
@@ -203,7 +203,9 @@ directories = [
   node['cassandra']['root_dir'],
   node['cassandra']['lib_dir'],
   node['cassandra']['pid_dir'],
-  node['cassandra']['data_dir']
+  node['cassandra']['data_dir'],
+  node['cassandra']['commitlog_dir'],
+  node['cassandra']['saved_caches_dir']
 ]
 
 # including hints directory, in case is part of configuration

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -35,6 +35,8 @@ describe 'cassandra-dse::default' do
           /var/log/cassandra
           /var/lib/cassandra
           /var/lib/cassandra/data
+          /var/lib/cassandra/commitlog
+          /var/lib/cassandra/saved_caches
           /var/run/cassandra
           /usr/share/cassandra
           /usr/share/cassandra/lib


### PR DESCRIPTION
The commitlog and saved_caches dir were added to the tarball
installation recipe in
https://github.com/michaelklishin/cassandra-chef-cookbook/pull/305. This
change adds them into the datastax installation recipe and updates the
tests to validate the addition.