### PR TITLE
Only install jamm if setup requested

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -113,6 +113,7 @@ describe 'cassandra-dse::config' do
         node.default['cassandra']['saved_caches_dir'] = '/var/lib/cassandra/saved_caches'
         node.default['cassandra']['snitch_conf'] = { 'dc' => 'testdc', 'rack' => 'testrack' }
         node.override['cassandra']['setup_priam'] = true
+        node.override['cassandra']['setup_jamm'] = true
         node.override['cassandra']['setup_jna'] = true
         node.override['cassandra']['notify_restart'] = true
         node.override['cassandra']['jvm']['g1'] = true

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -213,7 +213,7 @@ fi
 # provides hints to the JIT compiler
 JVM_OPTS="$JVM_OPTS -XX:CompileCommandFile=$CASSANDRA_CONF/hotspot_compiler"
 
-<% if node['cassandra']['jamm']['version'] -%>
+<% if node['cassandra']['setup_jamm'] -%>
 # add the jamm javaagent
 if [ "$JVM_VENDOR" != "OpenJDK" -o "$JVM_VERSION" \> "1.6.0" ] \
       || [ "$JVM_VERSION" = "1.6.0" -a "$JVM_PATCH_VERSION" -ge 23 ]


### PR DESCRIPTION
Hello,

Even if we let the default parameter for setup_jamm to false in https://github.com/michaelklishin/cassandra-chef-cookbook/blob/master/attributes/default.rb#L26, the cookbook try to install it as it compute a version here https://github.com/michaelklishin/cassandra-chef-cookbook/blob/master/attributes/default.rb#L112.

This PR aims to correctly use the attribute setup_jamm in order to decide either or not install a special version