### PR TITLE
Switch to standardized node attribute syntax. Fixes #350

### DIFF
--- a/templates/default/cqlsh.erb
+++ b/templates/default/cqlsh.erb
@@ -3,4 +3,4 @@
 # This file is managed by Chef.
 # Do NOT modify this file directly.
 #
-exec  <%= node.cassandra.bin_dir %>/cqlsh "$@"
+exec  <%= node['cassandra']['bin_dir'] %>/cqlsh "$@"

--- a/templates/default/debian.cassandra.init.erb
+++ b/templates/default/debian.cassandra.init.erb
@@ -20,15 +20,15 @@ DESC="Cassandra"
 NAME=cassandra
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-export CASSANDRA_HOME=<%= node.cassandra.installation_dir %>
-export CASSANDRA_CONF=<%= node.cassandra.conf_dir %>
-USER=<%= node.cassandra.user %>
-GROUP=<%= node.cassandra.group %>
+export CASSANDRA_HOME=<%= node['cassandra']['installation_dir'] %>
+export CASSANDRA_CONF=<%= node['cassandra']['conf_dir'] %>
+USER=<%= node['cassandra']['user'] %>
+GROUP=<%= node['cassandra']['group'] %>
 WAIT_FOR_START=10
-FD_LIMIT=<%= node.cassandra.limits.nofile %>
+FD_LIMIT=<%= node['cassandra']['limits']['nofile'] %>
 NODETOOL=$CASSANDRA_HOME/bin/nodetool
 
-[ -e $CASSANDRA_HOME/lib/apache-cassandra-<%= node.cassandra.version %>.jar ] || exit 0
+[ -e $CASSANDRA_HOME/lib/apache-cassandra-<%= node['cassandra']['version'] %>.jar ] || exit 0
 [ -e $CASSANDRA_CONF/cassandra.yaml ] || exit 0
 [ -e $CASSANDRA_CONF/cassandra-env.sh ] || exit 0
 [ -e $CASSANDRA_HOME/bin/cassandra ] || exit 0
@@ -76,7 +76,7 @@ do_start()
         --chuid $USER:$GROUP \
         --exec /bin/bash \
         --pidfile $PIDFILE \
-        -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE > <%= node.cassandra.log_dir %>/boot.log 2>&1"
+        -- -c "$CASSANDRA_HOME/bin/cassandra -p $PIDFILE > <%= node['cassandra']['log_dir'] %>/boot.log 2>&1"
 
     is_running && return 0
 
@@ -99,7 +99,7 @@ do_stop()
 
   # Disable Thrift, Mark node down for client
   echo "executing nodetool disablethrift .."
-  $NODETOOL -h <%=node.ipaddress%> disablethrift
+  $NODETOOL -h <%=node['ipaddress']%> disablethrift
   [ $? -eq 0 ] || {
     echo "failed to execute disablethrift .."
   }
@@ -107,7 +107,7 @@ do_stop()
 
   # Disabling Gossip, Mark node down for cluster
   echo "executing nodetool disablegossip .."
-  $NODETOOL -h <%=node.ipaddress%> disablegossip
+  $NODETOOL -h <%=node['ipaddress']%> disablegossip
   [ $? -eq 0 ] || {
     echo "failed to execute disablegossip .."
   }
@@ -115,7 +115,7 @@ do_stop()
 
   # Drain node for existing connections, Always safe even takes long time
   echo "executing nodetool drain .."
-  $NODETOOL -h <%=node.ipaddress%> drain
+  $NODETOOL -h <%=node['ipaddress']%> drain
   [ $? -eq 0 ] || {
     echo "failed to execute drain .."
   }

--- a/templates/default/jvm.options.erb
+++ b/templates/default/jvm.options.erb
@@ -187,7 +187,7 @@
 #-Xms4G
 #-Xmx4G
 <% if node['cassandra']['jvm'] && node['cassandra']['jvm']['xms'] -%>
-# (set via node.cassandra.jvm.xms)
+# (set via node['cassandra']['jvm']['xms'])
 -Xms<%= node['cassandra']['jvm']['xms'] %>
 <% end -%>
 <% if node['cassandra']['jvm'] && node['cassandra']['jvm']['xmx'] -%>

--- a/templates/default/log4j-server.properties.erb
+++ b/templates/default/log4j-server.properties.erb
@@ -22,7 +22,7 @@
 # (%l is slower.)
 
 # output messages into a rolling log file as well as stdout
-log4j.rootLogger=<%= node.cassandra.rootlogger %>
+log4j.rootLogger=<%= node['cassandra']['rootlogger'] %>
 
 # stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
@@ -36,7 +36,7 @@ log4j.appender.R.maxBackupIndex=50
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
 log4j.appender.R.layout.ConversionPattern=%5p [%t] %d{ISO8601} %F (line %L) %m%n
 # Edit the next line to point to your logs directory
-log4j.appender.R.File=<%= node.cassandra.log_dir %>/system.log
+log4j.appender.R.File=<%= node['cassandra']['log_dir'] %>/system.log
 
 # Application logging options
 #log4j.logger.org.apache.cassandra=DEBUG
@@ -46,7 +46,7 @@ log4j.appender.R.File=<%= node.cassandra.log_dir %>/system.log
 # Adding this to avoid thrift logging disconnect errors.
 log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
 
-<% node.cassandra.log4j.each do |key, value| %> 
+<% node['cassandra']['log4j'].each do |key, value| %> 
 <%= key %>=<%= value %>
 <% end %>
 

--- a/templates/default/logback.xml.erb
+++ b/templates/default/logback.xml.erb
@@ -116,7 +116,4 @@
 
   <logger name="org.apache.cassandra" level="INFO"/>
   <logger name="com.thinkaurelius.thrift" level="ERROR"/>
-  <% node['cassandra']['logback']['override_loggers'].each do |logger, level| %>
-  <logger name="<%= logger %>" level="<%= level %>"/>
-  <% end %>
 </configuration>

--- a/templates/default/rhel.cassandra.init.erb
+++ b/templates/default/rhel.cassandra.init.erb
@@ -4,22 +4,22 @@
 # Do NOT modify this file directly.
 #
 # chkconfig: 345 20 80
-# description: <%=node.cassandra.service_name%> daemon
-# processname: <%=node.cassandra.service_name%>
+# description: <%=node['cassandra']['service_name']%> daemon
+# processname: <%=node['cassandra']['service_name']%>
 
-export CASSANDRA_HOME=<%=node.cassandra.installation_dir%>
-export CASSANDRA_CONF=<%=node.cassandra.conf_dir%>
+export CASSANDRA_HOME=<%=node['cassandra']['installation_dir']%>
+export CASSANDRA_CONF=<%=node['cassandra']['conf_dir']%>
 NODETOOL=$CASSANDRA_HOME/bin/nodetool
 
-SERVICE_USER=<%=node.cassandra.user%>
-SERVICE_GROUP=<%=node.cassandra.group%>
+SERVICE_USER=<%=node['cassandra']['user']%>
+SERVICE_GROUP=<%=node['cassandra']['group']%>
 
-PROGRAM=<%=node.cassandra.service_name%>
-SERVICE_PID_FILE=<%=node.cassandra.pid_dir%>/$PROGRAM.pid
+PROGRAM=<%=node['cassandra']['service_name']%>
+SERVICE_PID_FILE=<%=node['cassandra']['pid_dir']%>/$PROGRAM.pid
 
 SERVICE_EXEC=$CASSANDRA_HOME/bin/cassandra
 
-SERVICE_LOG_FILE=<%=node.cassandra.log_dir%>/boot.log
+SERVICE_LOG_FILE=<%=node['cassandra']['log_dir']%>/boot.log
 SERVICE_LOCK=/var/lock/subsys/$PROGRAM
 
 WAIT_FOR_START=10
@@ -34,8 +34,8 @@ WAIT_FOR_START=10
   exit 1
 }
 
-[ -e $CASSANDRA_HOME/lib/apache-cassandra-<%=node.cassandra.version%>.jar ] || {
-  echo "$PROGRAM missing $CASSANDRA_HOME/lib/apache-cassandra-<%=node.cassandra.version%>.jar  [failed]"
+[ -e $CASSANDRA_HOME/lib/apache-cassandra-<%=node['cassandra']['version']%>.jar ] || {
+  echo "$PROGRAM missing $CASSANDRA_HOME/lib/apache-cassandra-<%=node['cassandra']['version']%>.jar  [failed]"
   exit 1
 }
 
@@ -106,21 +106,21 @@ service_stop() {
   service_stop_pre_check
 
   echo "executing nodetool disablethrift .."
-  $NODETOOL -h <%=node.ipaddress%> disablethrift
+  $NODETOOL -h <%=node['ipaddress']%> disablethrift
   [ $? -eq 0 ] || {
     echo "failed to execute disablethrift .."
   }
   sleep 3
 
   echo "executing nodetool disablegossip .."
-  $NODETOOL -h <%=node.ipaddress%> disablegossip 
+  $NODETOOL -h <%=node['ipaddress']%> disablegossip 
   [ $? -eq 0 ] || {
     echo "failed to execute disablegossip .."
   }
   sleep 3
 
   echo "executing nodetool drain .."
-  $NODETOOL -h <%=node.ipaddress%> drain
+  $NODETOOL -h <%=node['ipaddress']%> drain
   [ $? -eq 0 ] || {
     echo "failed to execute drain .."
   }


### PR DESCRIPTION
Chef 13+ no longer has the node method sytnax, see https://docs.chef.io/deprecations_attributes.html