### PR TITLE
enable_assertions docs is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ some recently added attributes. Please refer to the [attributes files](https://g
  * `node[:cassandra][:heap_dump]` -XX:+HeapDumpOnOutOfMemoryError JVM parameter (default: true)
  * `node[:cassandra][:heap_dump_dir]` Directory where heap dumps will be placed (default: nil, which will use cwd)
  * `node[:cassandra][:vnodes]` enable vnodes. (default: true)
+ * `node[:cassandra][:enable_assertions]` Enable JVM assertions.  Disabling this in production will give a modest performance benefit (around 5%) (default: true).
 
  For the complete set of supported attributes, please consult [the source](https://github.com/michaelklishin/cassandra-chef-cookbook/tree/master/attributes).
 
@@ -274,7 +275,6 @@ Oracle JVM 8 tuning parameters: [here](https://docs.oracle.com/javase/8/docs/tec
  * `node[:cassandra][:config][:request_scheduler]` Class to schedule incoming client requests (default: org.apache.cassandra.scheduler.NoScheduler)
  * `node[:cassandra][:config][:index_interval]` index\_interval controls the sampling of entries from the primary row index in terms of space versus time (default: 128).
  * `node[:cassandra][:config][:auto_bootstrap]` Setting this parameter to false prevents the new nodes from attempting to get all the data from the other nodes in the data center. (default: true).
- * `node[:cassandra][:config][:enable_assertions]` Enable JVM assertions.  Disabling this in production will give a modest performance benefit (around 5%) (default: true).
  * `node[:cassandra][:config][:data_file_directories]` (default: node['cassandra']['data_dir']): C* data cirectories
  * `node[:cassandra][:config][:saved_caches_directory]` (default: saved_caches_directory): C* saved cache directory
  * `node[:cassandra][:config][:commitlog_directory]` (default: node['cassandra']['commitlog_dir']) *C commit log directory


### PR DESCRIPTION
enable_assertions docs is wrong, templates/default/jvm.options.erb referrer to node['cassandra']['enable_assertions']