### PR TITLE
Allows -XX:OnOutOfMemoryError flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ some recently added attributes. Please refer to the [attributes files](https://g
  * `node[:cassandra][:heap_dump_dir]` Directory where heap dumps will be placed (default: nil, which will use cwd)
  * `node[:cassandra][:vnodes]` enable vnodes. (default: true)
  * `node[:cassandra][:enable_assertions]` Enable JVM assertions.  Disabling this in production will give a modest performance benefit (around 5%) (default: true).
+ * `node[:cassandra][:on_oom]` -XX:OnOutOfMemoryError JVM parameter (default: kill -9 %p)
 
  For the complete set of supported attributes, please consult [the source](https://github.com/michaelklishin/cassandra-chef-cookbook/tree/master/attributes).
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Attributes for enabling G1 GC.
 Attributes for enabling GC detail/logging.
 
  * `node[:cassandra][:jvm][:gcdetail]` (default: false)
+ * `node[:cassandra][:log_gc]` -Xloggc JVM parameter (default: ${CASSANDRA_HOME}/logs/gc.log)
 
 Attributes for fine tuning the G1 GC algorithm:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -117,9 +117,10 @@ default['cassandra']['jamm']['sha256sum'] = jamm_sha256sum(node['cassandra']['ja
 # log configuration files
 default['cassandra']['log_config_files'] = node['cassandra']['version'] =~ /^[0-1]|^2.0/ ? %w[log4j-server.properties] : %w[logback.xml logback-tools.xml]
 
-# Heap Dump
+# Heap Dump and Out of Memory handling
 default['cassandra']['heap_dump'] = true
 default['cassandra']['heap_dump_dir'] = nil
+default['cassandra']['on_oom'] = 'kill -9 %p'
 
 # GC tuning options
 default['cassandra']['jvm']['g1'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -146,6 +146,7 @@ default['cassandra']['jvm']['misc_jvm_options'] = []
 default['cassandra']['gc_survivor_ratio'] = 8
 default['cassandra']['gc_max_tenuring_threshold'] = 1
 default['cassandra']['gc_cms_initiating_occupancy_fraction'] = 75
+default['cassandra']['log_gc'] = '${CASSANDRA_HOME}/logs/gc.log'
 
 default['cassandra']['jna']['base_url'] = 'https://github.com/twall/jna/raw/4.0/dist'
 default['cassandra']['jna']['jar_name'] = 'jna.jar'

--- a/spec/rendered_templates/cassandra-env.sh
+++ b/spec/rendered_templates/cassandra-env.sh
@@ -220,6 +220,14 @@ if [ "x$CASSANDRA_HEAPDUMP_DIR" != "x" ]; then
     JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 fi
 
+# stop the jvm on OutOfMemoryError as it can result in some data corruption
+# uncomment the preferred option
+# ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92
+# For OnOutOfMemoryError we cannot use the JVM_OPTS variables because bash commands split words
+# on white spaces without taking quotes into account
+# JVM_OPTS="$JVM_OPTS -XX:+ExitOnOutOfMemoryError"
+# JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
+JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=kill -9 %p"
 
 #
 # see

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -123,7 +123,7 @@ case "$jvm" in
 esac
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xloggc:<%= node['cassandra']['log_gc'] %>"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.

--- a/templates/default/cassandra-env.sh.erb
+++ b/templates/default/cassandra-env.sh.erb
@@ -230,6 +230,14 @@ if [ "x$CASSANDRA_HEAPDUMP_DIR" != "x" ]; then
     JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 fi
 
+# stop the jvm on OutOfMemoryError as it can result in some data corruption
+# uncomment the preferred option
+# ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92
+# For OnOutOfMemoryError we cannot use the JVM_OPTS variables because bash commands split words
+# on white spaces without taking quotes into account
+# JVM_OPTS="$JVM_OPTS -XX:+ExitOnOutOfMemoryError"
+# JVM_OPTS="$JVM_OPTS -XX:+CrashOnOutOfMemoryError"
+JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=<%= node['cassandra']['on_oom'] %>"
 
 #
 # see


### PR DESCRIPTION
Allows users to define `OnOutOfMemoryError`, and default to
upstream Cassandra settings (kill the process):
https://github.com/apache/cassandra/blob/439c8278f00d0b571f66190e5572371f6e8e4e59/conf/cassandra-env.sh#L189

Cassandra catches OutOfMemory exceptions to give users the opportunity
to run an OOM handler script (eg. for diagnostics, or monitoring, or
to handle restarts), but expects that script to stop the JVM anyway.

Failing to do so will leave a corrupted Cassandra process (having
lost some arbitrary threads) hanging around, which won't recover.

The `-XX:+CrashOnOutOfMemoryError` Java flag would provide builtin
native JVM exits, but would also require Java 8u92+.
`-XX:+OnOutOfMemoryError` flag is both more flexible, and compatible
with older versions.

The `$JVM_ON_OUT_OF_MEMORY_ERROR_OPT` variable is consumed by `bin/cassandra`:
https://github.com/apache/cassandra/blob/6ba2fb9395226491872b41312d978a169f36fcdb/bin/cassandra#L181

While at it, also allow users to provide an alternate GC logs path.
