### PR TITLE
Constraint java version < 8.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/michaelklishin/cassandra-chef-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/michaelklishin/cassandra-chef-cookbook/issues' if respond_to?(:issues_url)
 version '4.6.0'
-depends 'java'
+depends 'java', '< 8.0.0'
 depends 'ulimit'
 depends 'apt'
 depends 'yum'


### PR DESCRIPTION
  + Java cookbook broke interface at 8.0.0 version moving from recipe
    to ressources. As the cassandra cookbook is not ready yet,
    Constraint the java version to be under 8.0.0